### PR TITLE
fix membership transfer auto-approve compatibility

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -493,6 +493,9 @@ export interface MembershipTransferRequestData {
   createdAt: string;
   updatedAt: string;
   reviewedAt: string | null;
+  // Backward compatibility: older backend responses expose reviewer ID directly.
+  reviewedByAdminId?: string | null;
+  // New safer shape from backend that avoids leaking admin UUIDs to end users.
   reviewedBySystem?: boolean;
 }
 

--- a/src/components/MembershipTransferDialog.tsx
+++ b/src/components/MembershipTransferDialog.tsx
@@ -149,7 +149,8 @@ export function MembershipTransferDialog({ open, onOpenChange }: Props) {
 
   const isAutoApproved =
     existing?.status === "APPROVED" &&
-    existing?.reviewedBySystem === true;
+    (existing?.reviewedBySystem === true ||
+      existing?.reviewedByAdminId === "system_auto_approval");
 
   const handleOpenChange = (nextOpen: boolean) => {
     onOpenChange(nextOpen);


### PR DESCRIPTION
Support both legacy reviewedByAdminId and new reviewedBySystem fields so auto-approved requests still redirect correctly during staggered backend/frontend deployments.