### PR TITLE
Add admin dashboard for VPN engagement and user session history.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,10 +36,16 @@ const AdminOverview = lazy(() => import("./pages/admin/AdminOverview"));
 const AdminProductEvents = lazy(
   () => import("./pages/admin/AdminProductEvents"),
 );
+const AdminConnectionEngagement = lazy(
+  () => import("./pages/admin/AdminConnectionEngagement"),
+);
 const AdminSubscriptions = lazy(
   () => import("./pages/admin/AdminSubscriptions"),
 );
 const AdminUsers = lazy(() => import("./pages/admin/AdminUsers"));
+const AdminUserSessions = lazy(
+  () => import("./pages/admin/AdminUserSessions"),
+);
 
 const queryClient = new QueryClient();
 
@@ -112,7 +118,15 @@ const App = () => (
                   element={<Navigate to="/admin/overview" replace />}
                 />
                 <Route path="overview" element={<AdminOverview />} />
+                <Route
+                  path="user-sessions/:userId"
+                  element={<AdminUserSessions />}
+                />
                 <Route path="product-events" element={<AdminProductEvents />} />
+                <Route
+                  path="connection-engagement"
+                  element={<AdminConnectionEngagement />}
+                />
                 <Route
                   path="membership-transfer"
                   element={<MembershipTransferAdmin />}

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -1170,6 +1170,49 @@ export interface AdminIpAddressClickSummary {
   topServerLocations: { label: string; count: number }[];
 }
 
+export interface AdminMedianMonthlySessionsSummary {
+  month: string;
+  median_sessions_per_user: number;
+  mean_sessions_per_user: number;
+  users_with_sessions: number;
+  total_sessions: number;
+  percentiles: {
+    p25: number;
+    p50: number;
+    p75: number;
+    p90: number;
+    p95: number;
+  };
+  filters: {
+    min_duration_seconds: number;
+    exclude_email_patterns: string[];
+    exclude_platforms: string[];
+  };
+}
+
+export interface AdminMedianMonthlySessionsReport {
+  summary: AdminMedianMonthlySessionsSummary;
+  histogram: { session_count: number; users: number }[];
+  segments: {
+    platform: AdminEngagementSegment[];
+    subscription_tier: AdminEngagementSegment[];
+    acquisition_source: AdminEngagementSegment[];
+  };
+  month_over_month: {
+    previous_month: string;
+    median_sessions_per_user: number;
+    users_with_sessions: number;
+    delta_median: number;
+  } | null;
+}
+
+export interface AdminEngagementSegment {
+  segment: string;
+  median_sessions_per_user: number;
+  users_with_sessions: number;
+  total_sessions: number;
+}
+
 export interface AdminSubscriptionListItem {
   id: string;
   status: string;
@@ -1277,6 +1320,75 @@ export async function adminFetchMe(): Promise<{
   }
 }
 
+export interface AdminConnectionSession {
+  id: string;
+  client_session_id: string;
+  session_start: string;
+  session_end: string | null;
+  duration_seconds: number;
+  platform: string;
+  app_version: string | null;
+  server_location: string | null;
+  bytes_transferred: number;
+  subscription_tier: string | null;
+  termination_reason: string;
+  disconnect_reason: string | null;
+}
+
+export interface AdminUserConnectionSessionsResponse {
+  user: {
+    id: string;
+    email: string;
+    name: string | null;
+    provider: string;
+    longestSessionSeconds: number;
+    createdAt: string;
+  };
+  sessions: AdminConnectionSession[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export async function adminFetchUserConnectionSessions(
+  userId: string,
+  params?: { limit?: number; offset?: number; signal?: AbortSignal },
+): Promise<{
+  ok: boolean;
+  data?: AdminUserConnectionSessionsResponse;
+  error?: string;
+}> {
+  try {
+    const query = new URLSearchParams();
+    query.set("limit", String(params?.limit ?? 50));
+    query.set("offset", String(params?.offset ?? 0));
+    const response = await fetch(
+      `${BACKEND_URL}/admin/users/${encodeURIComponent(userId)}/connection-sessions?${query.toString()}`,
+      {
+        credentials: "include",
+        signal: params?.signal,
+      },
+    );
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(
+          raw,
+          "Failed to load connection sessions",
+        ),
+      };
+    }
+    const record = raw as { data?: AdminUserConnectionSessionsResponse };
+    return { ok: true, data: record.data };
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Network error",
+    };
+  }
+}
+
 export async function adminFetchUsersOverview(params?: {
   page?: number;
   limit?: number;
@@ -1303,6 +1415,57 @@ export async function adminFetchUsersOverview(params?: {
       };
     }
     const record = raw as { data?: AdminUserOverview };
+    return { ok: true, data: record.data };
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Network error",
+    };
+  }
+}
+
+export async function adminFetchMedianMonthlySessions(params?: {
+  month?: string;
+  minDurationSeconds?: number;
+  excludePlatforms?: string;
+  includeMom?: boolean;
+  signal?: AbortSignal;
+}): Promise<{
+  ok: boolean;
+  data?: AdminMedianMonthlySessionsReport;
+  error?: string;
+}> {
+  try {
+    const query = new URLSearchParams();
+    if (params?.month) query.set("month", params.month);
+    if (params?.minDurationSeconds != null) {
+      query.set("min_duration_seconds", String(params.minDurationSeconds));
+    }
+    if (params?.excludePlatforms) {
+      query.set("exclude_platforms", params.excludePlatforms);
+    }
+    if (params?.includeMom === false) {
+      query.set("include_mom", "false");
+    }
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    const response = await fetch(
+      `${BACKEND_URL}/admin/connection-engagement/median-monthly-sessions${suffix}`,
+      {
+        credentials: "include",
+        signal: params?.signal,
+      },
+    );
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(
+          raw,
+          "Failed to load connection engagement",
+        ),
+      };
+    }
+    const record = raw as { data?: AdminMedianMonthlySessionsReport };
     return { ok: true, data: record.data };
   } catch (e) {
     return {

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -1444,6 +1444,8 @@ export async function adminFetchMedianMonthlySessions(params?: {
     if (params?.excludePlatforms) {
       query.set("exclude_platforms", params.excludePlatforms);
     }
+    // Omit include_mom unless opting out — backend defaults to true (MoM included).
+    // AdminConnectionEngagement never passes includeMom, so month_over_month is always returned.
     if (params?.includeMom === false) {
       query.set("include_mom", "false");
     }

--- a/src/components/admin/AdminSidebarLayout.tsx
+++ b/src/components/admin/AdminSidebarLayout.tsx
@@ -9,6 +9,7 @@ import {
   BarChart3,
   CreditCard,
   Users,
+  Activity,
 } from "lucide-react";
 
 function linkClass(isActive: boolean) {
@@ -66,6 +67,13 @@ export default function AdminSidebarLayout() {
             >
               <BarChart3 className="h-4 w-4" />
               Product Events
+            </NavLink>
+            <NavLink
+              to="/admin/connection-engagement"
+              className={({ isActive }) => linkClass(isActive)}
+            >
+              <Activity className="h-4 w-4" />
+              Connection Engagement
             </NavLink>
             <NavLink
               to="/admin/subscriptions"

--- a/src/pages/admin/AdminConnectionEngagement.tsx
+++ b/src/pages/admin/AdminConnectionEngagement.tsx
@@ -46,11 +46,11 @@ const distributionChartConfig = {
   },
 } satisfies ChartConfig;
 
-type DistributionChartRow = {
+interface DistributionChartRow {
   session_count: number;
   sessionLabel: string;
   users: number;
-};
+}
 
 function DistributionTooltip({
   active,

--- a/src/pages/admin/AdminConnectionEngagement.tsx
+++ b/src/pages/admin/AdminConnectionEngagement.tsx
@@ -1,0 +1,483 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Label,
+  LabelList,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipProps } from "recharts";
+import {
+  adminFetchMedianMonthlySessions,
+  type AdminEngagementSegment,
+  type AdminMedianMonthlySessionsReport,
+} from "@/auth/backend";
+import {
+  ChartContainer,
+  ChartTooltip,
+  type ChartConfig,
+} from "@/components/ui/chart";
+
+function currentMonthValue(): string {
+  const now = new Date();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${now.getUTCFullYear()}-${month}`;
+}
+
+function formatMonthSubtitle(month: string): string {
+  const match = /^(\d{4})-(\d{2})$/.exec(month);
+  if (!match) {
+    return month;
+  }
+  const date = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, 1));
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+const distributionChartConfig = {
+  users: {
+    label: "Users",
+    color: "hsl(var(--primary))",
+  },
+} satisfies ChartConfig;
+
+type DistributionChartRow = {
+  session_count: number;
+  sessionLabel: string;
+  users: number;
+};
+
+function DistributionTooltip({
+  active,
+  payload,
+}: TooltipProps<number, string>) {
+  if (!active || !payload?.length) {
+    return null;
+  }
+  const row = payload[0]?.payload as DistributionChartRow | undefined;
+  if (!row) {
+    return null;
+  }
+  const userWord = row.users === 1 ? "user" : "users";
+  const sessionWord = row.session_count === 1 ? "session" : "sessions";
+  return (
+    <div className="rounded-lg border border-border bg-background px-3 py-2 text-xs shadow-lg">
+      <p className="font-medium text-foreground">
+        {row.users} {userWord} had exactly {row.session_count} {sessionWord}{" "}
+        this month
+      </p>
+    </div>
+  );
+}
+
+function barValueLabel(value: number) {
+  const count = Number(value);
+  if (!Number.isFinite(count)) {
+    return "";
+  }
+  return `${count} ${count === 1 ? "user" : "users"}`;
+}
+
+function SegmentTable({
+  title,
+  rows,
+  loading,
+}: {
+  title: string;
+  rows: AdminEngagementSegment[];
+  loading: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <h3 className="text-sm font-semibold">{title}</h3>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-muted-foreground">
+              <th className="pb-2 pr-4 font-medium">Segment</th>
+              <th className="pb-2 pr-4 font-medium text-right">Median</th>
+              <th className="pb-2 pr-4 font-medium text-right">Users</th>
+              <th className="pb-2 font-medium text-right">Sessions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.segment} className="border-t border-border/60">
+                <td className="py-2 pr-4 text-muted-foreground">
+                  {row.segment}
+                </td>
+                <td className="py-2 pr-4 text-right font-mono tabular-nums">
+                  {row.median_sessions_per_user}
+                </td>
+                <td className="py-2 pr-4 text-right font-mono tabular-nums">
+                  {row.users_with_sessions}
+                </td>
+                <td className="py-2 text-right font-mono tabular-nums">
+                  {row.total_sessions}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {loading && rows.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">Loading…</p>
+        ) : null}
+        {!loading && rows.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">No data.</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function HistogramChart({
+  buckets,
+  loading,
+  monthLabel,
+}: {
+  buckets: { session_count: number; users: number }[];
+  loading: boolean;
+  monthLabel: string;
+}) {
+  const chartData = useMemo<DistributionChartRow[]>(
+    () =>
+      [...buckets]
+        .sort((a, b) => a.session_count - b.session_count)
+        .map((bucket) => ({
+          session_count: bucket.session_count,
+          sessionLabel: String(bucket.session_count),
+          users: bucket.users,
+        })),
+    [buckets],
+  );
+
+  const monthTitle = formatMonthSubtitle(monthLabel);
+
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <h3 className="text-sm font-semibold">Sessions per user (distribution)</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Each bar shows how many users had that exact session count in{" "}
+        {monthTitle}.
+      </p>
+
+      {loading && chartData.length === 0 ? (
+        <p className="mt-6 text-sm text-muted-foreground">Loading…</p>
+      ) : null}
+
+      {!loading && chartData.length === 0 ? (
+        <p className="mt-6 text-sm text-muted-foreground">
+          No sessions recorded.
+        </p>
+      ) : null}
+
+      {chartData.length > 0 ? (
+        <ChartContainer
+          config={distributionChartConfig}
+          className="mt-4 aspect-[5/2] min-h-[280px] w-full"
+        >
+          <BarChart
+            data={chartData}
+            margin={{ top: 32, right: 16, left: 20, bottom: 56 }}
+          >
+            <CartesianGrid vertical={false} strokeDasharray="3 3" />
+            <XAxis
+              dataKey="sessionLabel"
+              type="category"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              interval={0}
+            >
+              <Label
+                value="Sessions per user"
+                position="insideBottom"
+                offset={-40}
+                className="fill-muted-foreground text-xs"
+              />
+            </XAxis>
+            <YAxis
+              dataKey="users"
+              allowDecimals={false}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              width={48}
+            >
+              <Label
+                value="Number of users"
+                angle={-90}
+                position="insideLeft"
+                offset={12}
+                className="fill-muted-foreground text-xs"
+              />
+            </YAxis>
+            <ChartTooltip
+              cursor={{ fill: "hsl(var(--muted) / 0.35)" }}
+              content={<DistributionTooltip />}
+            />
+            <Bar
+              dataKey="users"
+              fill="var(--color-users)"
+              radius={[4, 4, 0, 0]}
+              maxBarSize={56}
+            >
+              <LabelList
+                dataKey="users"
+                position="top"
+                className="fill-foreground text-[11px] font-medium"
+                formatter={barValueLabel}
+              />
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+      ) : null}
+    </div>
+  );
+}
+
+
+export default function AdminConnectionEngagement() {
+  const [report, setReport] = useState<AdminMedianMonthlySessionsReport | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [monthInput, setMonthInput] = useState(currentMonthValue);
+  const [minDurationInput, setMinDurationInput] = useState("10");
+  const [excludeExtension, setExcludeExtension] = useState(false);
+  const activeRequest = useRef<AbortController | null>(null);
+
+  const load = useCallback(
+    async (
+      month: string,
+      minDuration: string,
+      excludeIosExtension: boolean,
+    ) => {
+      activeRequest.current?.abort();
+      const controller = new AbortController();
+      activeRequest.current = controller;
+
+      setLoading(true);
+      setError(null);
+
+      const parsedMin = Number(minDuration);
+      if (!Number.isInteger(parsedMin) || parsedMin < 0) {
+        setReport(null);
+        setError("Min duration must be a non-negative whole number");
+        setLoading(false);
+        activeRequest.current = null;
+        return;
+      }
+
+      const res = await adminFetchMedianMonthlySessions({
+        month,
+        minDurationSeconds: parsedMin,
+        excludePlatforms: excludeIosExtension ? "ios_extension" : undefined,
+        signal: controller.signal,
+      });
+
+      if (controller.signal.aborted || activeRequest.current !== controller) {
+        return;
+      }
+
+      if (!res.ok || !res.data) {
+        setReport(null);
+        setError(res.error ?? "Failed to load connection engagement");
+        setLoading(false);
+        activeRequest.current = null;
+        return;
+      }
+
+      setReport(res.data);
+      setLoading(false);
+      activeRequest.current = null;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void load(currentMonthValue(), "10", false);
+    return () => activeRequest.current?.abort();
+  }, [load]);
+
+  const applyFilters = () => {
+    void load(monthInput, minDurationInput, excludeExtension);
+  };
+
+  const summary = report?.summary;
+  const mom = report?.month_over_month;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold">Connection engagement</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Median VPN sessions per user (calendar month, UTC). Typical usage
+            is better reflected by the median than the average.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={applyFilters}
+          className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border p-4">
+        <label className="text-sm">
+          <span className="mb-1 block text-muted-foreground">Month (UTC)</span>
+          <input
+            type="month"
+            value={monthInput}
+            onChange={(event) => setMonthInput(event.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            Min duration (seconds)
+          </span>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            value={minDurationInput}
+            onChange={(event) => setMinDurationInput(event.target.value)}
+            className="w-28 rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="flex items-center gap-2 pb-2 text-sm">
+          <input
+            type="checkbox"
+            checked={excludeExtension}
+            onChange={(event) => setExcludeExtension(event.target.checked)}
+            className="rounded border-border"
+          />
+          <span className="text-muted-foreground">
+            Exclude iOS extension rows
+          </span>
+        </label>
+        <button
+          type="button"
+          onClick={applyFilters}
+          className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
+        >
+          Apply
+        </button>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-lg border border-border p-4">
+          <p className="text-sm text-muted-foreground">
+            Median sessions / user
+          </p>
+          <p className="mt-1 text-3xl font-semibold">
+            {summary?.median_sessions_per_user ?? (loading ? "…" : 0)}
+          </p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {summary?.month ?? monthInput}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border p-4">
+          <p className="text-sm text-muted-foreground">Users with sessions</p>
+          <p className="mt-1 text-3xl font-semibold">
+            {summary?.users_with_sessions ?? (loading ? "…" : 0)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border p-4">
+          <p className="text-sm text-muted-foreground">Total sessions</p>
+          <p className="mt-1 text-3xl font-semibold">
+            {summary?.total_sessions ?? (loading ? "…" : 0)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border p-4">
+          <p className="text-sm text-muted-foreground">Mean (reference only)</p>
+          <p className="mt-1 text-3xl font-semibold text-muted-foreground">
+            {summary?.mean_sessions_per_user ?? (loading ? "…" : 0)}
+          </p>
+          {mom ? (
+            <p className="mt-2 text-xs text-muted-foreground">
+              vs {mom.previous_month}:{" "}
+              <span
+                className={
+                  mom.delta_median >= 0
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-amber-600 dark:text-amber-400"
+                }
+              >
+                {mom.delta_median >= 0 ? "+" : ""}
+                {mom.delta_median} median
+              </span>{" "}
+              (prev {mom.median_sessions_per_user})
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {summary ? (
+        <div className="rounded-lg border border-border p-4">
+          <h3 className="text-sm font-semibold">Percentile distribution</h3>
+          <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-5">
+            {(
+              [
+                ["p25", summary.percentiles.p25],
+                ["p50", summary.percentiles.p50],
+                ["p75", summary.percentiles.p75],
+                ["p90", summary.percentiles.p90],
+                ["p95", summary.percentiles.p95],
+              ] as const
+            ).map(([label, value]) => (
+              <div key={label} className="rounded-md bg-muted/40 px-3 py-2">
+                <p className="text-xs uppercase text-muted-foreground">
+                  {label}
+                </p>
+                <p className="font-mono text-lg font-semibold tabular-nums">
+                  {value}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <HistogramChart
+        buckets={report?.histogram ?? []}
+        loading={loading}
+        monthLabel={summary?.month ?? monthInput}
+      />
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <SegmentTable
+          title="By platform"
+          rows={report?.segments.platform ?? []}
+          loading={loading}
+        />
+        <SegmentTable
+          title="By subscription tier"
+          rows={report?.segments.subscription_tier ?? []}
+          loading={loading}
+        />
+        <SegmentTable
+          title="By sign-in provider"
+          rows={report?.segments.acquisition_source ?? []}
+          loading={loading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminConnectionEngagement.tsx
+++ b/src/pages/admin/AdminConnectionEngagement.tsx
@@ -301,6 +301,8 @@ export default function AdminConnectionEngagement() {
     [],
   );
 
+  // Initial fetch uses literals that match useState defaults (not monthInput state).
+  // Same pattern as AdminProductEvents — load takes explicit args; [] deps is intentional.
   useEffect(() => {
     void load(currentMonthValue(), "10", false);
     return () => activeRequest.current?.abort();
@@ -392,6 +394,22 @@ export default function AdminConnectionEngagement() {
           <p className="mt-2 text-xs text-muted-foreground">
             {summary?.month ?? monthInput}
           </p>
+          {mom ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              vs {mom.previous_month}:{" "}
+              <span
+                className={
+                  mom.delta_median >= 0
+                    ? "text-emerald-600 dark:text-emerald-400"
+                    : "text-amber-600 dark:text-amber-400"
+                }
+              >
+                {mom.delta_median >= 0 ? "+" : ""}
+                {mom.delta_median} median
+              </span>{" "}
+              (prev {mom.median_sessions_per_user})
+            </p>
+          ) : null}
         </div>
         <div className="rounded-lg border border-border p-4">
           <p className="text-sm text-muted-foreground">Users with sessions</p>
@@ -410,22 +428,6 @@ export default function AdminConnectionEngagement() {
           <p className="mt-1 text-3xl font-semibold text-muted-foreground">
             {summary?.mean_sessions_per_user ?? (loading ? "…" : 0)}
           </p>
-          {mom ? (
-            <p className="mt-2 text-xs text-muted-foreground">
-              vs {mom.previous_month}:{" "}
-              <span
-                className={
-                  mom.delta_median >= 0
-                    ? "text-emerald-600 dark:text-emerald-400"
-                    : "text-amber-600 dark:text-amber-400"
-                }
-              >
-                {mom.delta_median >= 0 ? "+" : ""}
-                {mom.delta_median} median
-              </span>{" "}
-              (prev {mom.median_sessions_per_user})
-            </p>
-          ) : null}
         </div>
       </div>
 

--- a/src/pages/admin/AdminOverview.tsx
+++ b/src/pages/admin/AdminOverview.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { adminFetchUsersOverview, type AdminUserOverview } from "@/auth/backend";
 
 function formatDuration(seconds: number) {
@@ -112,6 +113,7 @@ export default function AdminOverview() {
               <th className="p-3">User</th>
               <th className="p-3">Longest session</th>
               <th className="p-3">Joined</th>
+              <th className="p-3">Sessions</th>
             </tr>
           </thead>
           <tbody>
@@ -120,11 +122,19 @@ export default function AdminOverview() {
                 <td className="p-3">{u.name ? `${u.name} (${u.email})` : u.email}</td>
                 <td className="p-3 font-mono">{formatDuration(u.longestSessionSeconds)}</td>
                 <td className="p-3 text-muted-foreground">{u.createdAt.slice(0, 10)}</td>
+                <td className="p-3">
+                  <Link
+                    to={`/admin/user-sessions/${u.id}`}
+                    className="text-primary hover:underline"
+                  >
+                    View sessions
+                  </Link>
+                </td>
               </tr>
             ))}
             {!loading && (overview?.users.length ?? 0) === 0 ? (
               <tr>
-                <td className="p-4 text-muted-foreground" colSpan={3}>
+                <td className="p-4 text-muted-foreground" colSpan={4}>
                   No users found.
                 </td>
               </tr>

--- a/src/pages/admin/AdminUserSessions.tsx
+++ b/src/pages/admin/AdminUserSessions.tsx
@@ -1,0 +1,232 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  adminFetchUserConnectionSessions,
+  type AdminConnectionSession,
+  type AdminUserConnectionSessionsResponse,
+} from "@/auth/backend";
+
+const PAGE_SIZE = 50;
+
+function formatDuration(seconds: number) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "0s";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+function formatBytes(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function formatDateTime(iso: string | null) {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+export default function AdminUserSessions() {
+  const { userId } = useParams<{ userId: string }>();
+  const [payload, setPayload] =
+    useState<AdminUserConnectionSessionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const activeRequest = useRef<AbortController | null>(null);
+
+  const load = useCallback(
+    async (targetPage: number) => {
+      if (!userId) {
+        setError("Missing user id");
+        setLoading(false);
+        return;
+      }
+
+      activeRequest.current?.abort();
+      const controller = new AbortController();
+      activeRequest.current = controller;
+
+      setLoading(true);
+      setError(null);
+
+      const offset = (targetPage - 1) * PAGE_SIZE;
+      const res = await adminFetchUserConnectionSessions(userId, {
+        limit: PAGE_SIZE,
+        offset,
+        signal: controller.signal,
+      });
+
+      if (controller.signal.aborted || activeRequest.current !== controller) {
+        return;
+      }
+
+      if (!res.ok || !res.data) {
+        setPayload(null);
+        setError(res.error ?? "Failed to load connection sessions");
+        setLoading(false);
+        activeRequest.current = null;
+        return;
+      }
+
+      setPayload(res.data);
+      setPage(targetPage);
+      setLoading(false);
+      activeRequest.current = null;
+    },
+    [userId],
+  );
+
+  useEffect(() => {
+    void load(1);
+    return () => activeRequest.current?.abort();
+  }, [load]);
+
+  const total = payload?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const user = payload?.user;
+  const sessions = payload?.sessions ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <Link
+            to="/admin/overview"
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            ← Back to overview
+          </Link>
+          <h2 className="mt-2 text-2xl font-bold">Connection sessions</h2>
+          {user ? (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {user.name ? `${user.name} · ` : ""}
+              {user.email} · {user.provider} · joined{" "}
+              {user.createdAt.slice(0, 10)}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => void load(page)}
+          className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="rounded-lg border border-border p-4">
+        <p className="text-sm text-muted-foreground">Total sessions</p>
+        <p className="mt-1 text-3xl font-semibold">{loading ? "…" : total}</p>
+        {user ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Longest session: {formatDuration(user.longestSessionSeconds)}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full min-w-[960px] text-sm">
+          <thead className="bg-muted/50">
+            <tr className="text-left">
+              <th className="p-3">Started</th>
+              <th className="p-3">Ended</th>
+              <th className="p-3">Duration</th>
+              <th className="p-3">Platform</th>
+              <th className="p-3">Location</th>
+              <th className="p-3">Tier</th>
+              <th className="p-3">Termination</th>
+              <th className="p-3 text-right">Bytes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.map((session: AdminConnectionSession) => (
+              <tr key={session.id} className="border-t border-border">
+                <td className="p-3 whitespace-nowrap text-muted-foreground">
+                  {formatDateTime(session.session_start)}
+                </td>
+                <td className="p-3 whitespace-nowrap text-muted-foreground">
+                  {formatDateTime(session.session_end)}
+                </td>
+                <td className="p-3 font-mono">
+                  {formatDuration(session.duration_seconds)}
+                </td>
+                <td className="p-3">{session.platform}</td>
+                <td className="p-3 text-muted-foreground">
+                  {session.server_location ?? "—"}
+                </td>
+                <td className="p-3">{session.subscription_tier ?? "—"}</td>
+                <td className="p-3 text-muted-foreground">
+                  <span className="block">{session.termination_reason}</span>
+                  {session.disconnect_reason ? (
+                    <span className="block text-xs">
+                      {session.disconnect_reason}
+                    </span>
+                  ) : null}
+                </td>
+                <td className="p-3 text-right font-mono tabular-nums">
+                  {formatBytes(session.bytes_transferred)}
+                </td>
+              </tr>
+            ))}
+            {!loading && sessions.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="p-4 text-muted-foreground">
+                  No connection sessions recorded for this user.
+                </td>
+              </tr>
+            ) : null}
+            {loading && sessions.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="p-4 text-muted-foreground">
+                  Loading…
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <p>
+          Page {page} of {totalPages} · showing {sessions.length} of {total}
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => void load(Math.max(1, page - 1))}
+            disabled={loading || page <= 1}
+            className="rounded-md border border-border px-3 py-1.5 hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            onClick={() => void load(Math.min(totalPages, page + 1))}
+            disabled={loading || page >= totalPages}
+            className="rounded-md border border-border px-3 py-1.5 hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add Connection Engagement page with median sessions, distribution chart, and segment breakdowns. Link Overview users to a paginated sessions detail view backed by the new admin connection-sessions API.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->