### PR TITLE
Use vpnkeen://open for web handoff and improve referral invite loading

### DIFF
--- a/src/lib/keenvpn-deep-links.ts
+++ b/src/lib/keenvpn-deep-links.ts
@@ -7,6 +7,9 @@ export const KEENVPN_URL_SCHEME = "vpnkeen";
 /** Post-Stripe checkout — app refreshes subscription status on open. */
 export const PAYMENT_SUCCESS_DEEP_LINK = `${KEENVPN_URL_SCHEME}://success`;
 
+/** Generic handoff from web (Header/Hero/Account) — foreground app without checkout UI. */
+export const OPEN_APP_DEEP_LINK = `${KEENVPN_URL_SCHEME}://open`;
+
 /** Checkout abandoned — app dismisses in-app checkout state. */
 export const PAYMENT_CANCEL_DEEP_LINK = `${KEENVPN_URL_SCHEME}://cancel`;
 

--- a/src/lib/open-app-or-store.ts
+++ b/src/lib/open-app-or-store.ts
@@ -2,7 +2,7 @@ import type { SubscriptionData } from "@/auth/types";
 import { detectDevice, isAppDeepLinkSupported } from "@/lib/device-detection";
 import {
   openKeenVpnNativeApp,
-  PAYMENT_SUCCESS_DEEP_LINK,
+  OPEN_APP_DEEP_LINK,
 } from "@/lib/keenvpn-deep-links";
 import { hasManageableSubscription } from "@/lib/subscription-cta";
 
@@ -27,12 +27,49 @@ export function shouldOpenNativeAppFirst(
   );
 }
 
+/** If the tab stays visible after a deep link, assume the app is not installed. */
+const APP_OPEN_FALLBACK_MS = 5000;
+
+function openKeenVpnNativeAppWithAppStoreFallback(
+  appStoreUrl: string,
+  deepLink: string = OPEN_APP_DEEP_LINK,
+): void {
+  let didLeavePage = false;
+
+  const markLeft = () => {
+    didLeavePage = true;
+  };
+
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "hidden") {
+      markLeft();
+    }
+  };
+
+  const cleanup = () => {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    window.removeEventListener("pagehide", markLeft);
+  };
+
+  document.addEventListener("visibilitychange", onVisibilityChange);
+  window.addEventListener("pagehide", markLeft);
+
+  openKeenVpnNativeApp(deepLink);
+
+  window.setTimeout(() => {
+    cleanup();
+    if (!didLeavePage) {
+      window.open(resolveAppStoreUrl(appStoreUrl), "_blank", "noopener,noreferrer");
+    }
+  }, APP_OPEN_FALLBACK_MS);
+}
+
 export function openAppOrAppStore(
   subscription: SubscriptionData | null | undefined,
   appStoreUrl: string,
 ): void {
   if (shouldOpenNativeAppFirst(subscription)) {
-    openKeenVpnNativeApp(PAYMENT_SUCCESS_DEEP_LINK);
+    openKeenVpnNativeAppWithAppStoreFallback(appStoreUrl);
     return;
   }
   window.open(resolveAppStoreUrl(appStoreUrl), "_blank", "noopener,noreferrer");

--- a/src/pages/ReferralLanding.tsx
+++ b/src/pages/ReferralLanding.tsx
@@ -29,6 +29,7 @@ const ReferralLanding = () => {
       navigate("/");
       return;
     }
+    setLoading(true);
     setReferrerName(null);
     setInviteInvalid(false);
     setReferralTokenStorage(token);


### PR DESCRIPTION
Open-app buttons use the dedicated deep link instead of payment success, with App Store fallback when the app is not installed. Reset loading when the referral token changes to avoid stale invite state.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->