### PR TITLE
Keep post-checkout Return to App UI visible until the user dismisses it.

### DIFF
--- a/src/lib/keenvpn-deep-links.ts
+++ b/src/lib/keenvpn-deep-links.ts
@@ -137,15 +137,11 @@ export function openKeenVpnNativeApp(deepLink: string = PAYMENT_SUCCESS_DEEP_LIN
 }
 
 /**
- * Return to the native app after Stripe checkout without tearing down the account UI first.
- * Dismisses post-checkout chrome only after a short delay so the browser sheet can close.
+ * Return to the native app after Stripe checkout. Does not hide post-checkout UI;
+ * callers should dismiss explicitly (e.g. "Continue on web") so users can retry the deep link.
  */
 export function returnToKeenVpnAppAfterPayment(
-  onDismissUi?: () => void,
   deepLink: string = PAYMENT_SUCCESS_DEEP_LINK,
 ): void {
   openKeenVpnNativeApp(deepLink);
-  if (onDismissUi) {
-    window.setTimeout(onDismissUi, 1200);
-  }
 }

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -77,6 +77,7 @@ import {
   clearStripeCheckoutReturn,
   dismissStripePostCheckoutUi,
   markStripeAutoOpenDone,
+  isStripeCheckoutReturn,
   markStripeCheckoutReturn,
   returnToKeenVpnAppAfterPayment,
   shouldAutoOpenAppAfterStripeCheckout,
@@ -143,29 +144,27 @@ const Account = () => {
     shouldShowStripePostCheckoutUi(),
   );
 
-  // Single source of truth for post-checkout UI: mark return from ?session_id=,
-  // sync banner visibility from sessionStorage, clear only when signed out (not while loading).
+  // Mark Stripe return as soon as session_id is present (before auth loading finishes).
+  // Otherwise already-signed-in ASWeb users briefly see the auth "Return to App" card instead.
   useEffect(() => {
-    if (loading) return;
-    if (!user) {
-      if (!hasSessionToken) {
-        clearStripeCheckoutReturn();
-        setShowPostCheckoutUi(false);
-      }
+    if (!hasStripeSessionId) {
       return;
     }
-    if (hasStripeSessionId) {
-      markStripeCheckoutReturn(stripeSessionId);
-    }
+    markStripeCheckoutReturn(stripeSessionId);
     setShowPostCheckoutUi(shouldShowStripePostCheckoutUi());
-  }, [user, loading, hasSessionToken, hasStripeSessionId, stripeSessionId]);
+  }, [hasStripeSessionId, stripeSessionId]);
+
+  // Clear post-checkout markers only when signed out (not while auth is loading).
+  useEffect(() => {
+    if (loading) return;
+    if (!user && !hasSessionToken) {
+      clearStripeCheckoutReturn();
+      setShowPostCheckoutUi(false);
+    }
+  }, [user, loading, hasSessionToken]);
 
   const showPaymentCompleteBanner =
-    Boolean(user) &&
-    hasSessionToken &&
-    showPostCheckoutUi &&
-    initialSubscriptionChecked &&
-    !subscriptionLoading;
+    Boolean(user) && hasSessionToken && showPostCheckoutUi;
 
   const showReturnToAppCta =
     showPaymentCompleteBanner && isDeepLinkSupported;
@@ -178,7 +177,7 @@ const Account = () => {
   };
 
   useEffect(() => {
-    if (!showPostCheckoutUi || !isDeepLinkSupported) {
+    if (!showPostCheckoutUi || !isDeepLinkSupported || isASWeb) {
       return;
     }
     if (!initialSubscriptionChecked || !shouldAutoOpenAppAfterStripeCheckout()) {
@@ -192,7 +191,12 @@ const Account = () => {
     }, 700);
 
     return () => window.clearTimeout(timer);
-  }, [showPostCheckoutUi, isDeepLinkSupported, initialSubscriptionChecked]);
+  }, [
+    showPostCheckoutUi,
+    isDeepLinkSupported,
+    isASWeb,
+    initialSubscriptionChecked,
+  ]);
 
   // The session token may not be in localStorage yet when Account first mounts
   // (AuthContext is still verifying with the backend). Poll until it arrives.
@@ -655,9 +659,8 @@ const Account = () => {
                         href={PAYMENT_SUCCESS_DEEP_LINK}
                         onClick={(event) => {
                           event.preventDefault();
-                          returnToKeenVpnAppAfterPayment(() => {
-                            dismissPostCheckoutUi();
-                          });
+                          markStripeAutoOpenDone();
+                          returnToKeenVpnAppAfterPayment();
                         }}
                       >
                         <Smartphone className="mr-2 h-5 w-5" />
@@ -665,8 +668,19 @@ const Account = () => {
                       </a>
                     </Button>
                     <p className="text-center text-xs text-muted-foreground">
-                      If the app did not open automatically, tap the button above.
+                      {isASWeb
+                        ? "Tap the button above to return to KeenVPN. This page stays open until you continue on web."
+                        : "If the app did not open automatically, tap the button above."}
                     </p>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground"
+                      onClick={dismissPostCheckoutUi}
+                    >
+                      Continue on web
+                    </Button>
                   </>
                 ) : (
                   <Button
@@ -682,8 +696,11 @@ const Account = () => {
             </Card>
           ) : null}
 
-          {/* ASWeb auth return — hidden when Stripe checkout just completed (success deep link instead) */}
-          {isASWeb && !showPostCheckoutUi && (
+          {/* ASWeb auth return — not during Stripe checkout return (payment banner uses vpnkeen://success) */}
+          {isASWeb &&
+            !showPostCheckoutUi &&
+            !hasStripeSessionId &&
+            !isStripeCheckoutReturn() && (
             <Card className="mb-8 border-primary/50 shadow-glow bg-primary/5">
               <CardContent className="flex flex-col items-center gap-4 py-6">
                 {isDeepLinkSupported ? (
@@ -867,9 +884,8 @@ const Account = () => {
                             href={PAYMENT_SUCCESS_DEEP_LINK}
                             onClick={(event) => {
                               event.preventDefault();
-                              returnToKeenVpnAppAfterPayment(() => {
-                                dismissPostCheckoutUi();
-                              });
+                              markStripeAutoOpenDone();
+                              returnToKeenVpnAppAfterPayment();
                             }}
                           >
                             <Smartphone className="mr-2 h-5 w-5" />

--- a/src/pages/Subscribe.tsx
+++ b/src/pages/Subscribe.tsx
@@ -417,7 +417,9 @@ const Subscribe = () => {
         return;
       }
 
-      const successUrl = `${window.location.origin}/account?session_id={CHECKOUT_SESSION_ID}`;
+      const aswebSuffix =
+        sessionStorage.getItem("asweb_session") === "1" ? "&asweb=1" : "";
+      const successUrl = `${window.location.origin}/account?session_id={CHECKOUT_SESSION_ID}${aswebSuffix}`;
       const cancelUrl = `${window.location.origin}/pricing`;
 
       const result = await createCheckoutSession(


### PR DESCRIPTION
Mark Stripe returns immediately for signed-in ASWeb users, avoid the auth handoff card during checkout, skip auto-open in ASWeb, and preserve asweb=1 on Stripe success URLs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->