### PR TITLE
Add month filters and connection counts to admin overview.

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -1358,11 +1358,17 @@ export interface AdminUserOverview {
   page: number;
   limit: number;
   totalPages: number;
+  month: string;
+  filters: {
+    min_duration_seconds: number;
+    exclude_platforms: string[];
+  };
   users: {
     id: string;
     email: string;
     name: string | null;
     longestSessionSeconds: number;
+    connectionCount: number;
     createdAt: string;
   }[];
 }
@@ -1599,6 +1605,9 @@ export async function adminFetchUsersOverview(params?: {
   page?: number;
   limit?: number;
   search?: string;
+  month?: string;
+  minDurationSeconds?: number;
+  excludePlatforms?: string;
 }): Promise<{
   ok: boolean;
   data?: AdminUserOverview;
@@ -1609,6 +1618,13 @@ export async function adminFetchUsersOverview(params?: {
     query.set("page", String(params?.page ?? 1));
     query.set("limit", String(params?.limit ?? 20));
     if (params?.search?.trim()) query.set("search", params.search.trim());
+    if (params?.month) query.set("month", params.month);
+    if (params?.minDurationSeconds != null) {
+      query.set("min_duration_seconds", String(params.minDurationSeconds));
+    }
+    if (params?.excludePlatforms) {
+      query.set("exclude_platforms", params.excludePlatforms);
+    }
     const suffix = query.toString() ? `?${query.toString()}` : "";
     const response = await fetch(`${BACKEND_URL}/admin/users/overview${suffix}`, {
       credentials: "include",

--- a/src/pages/admin/AdminOverview.tsx
+++ b/src/pages/admin/AdminOverview.tsx
@@ -2,6 +2,25 @@ import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { adminFetchUsersOverview, type AdminUserOverview } from "@/auth/backend";
 
+function currentMonthValue(): string {
+  const now = new Date();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${now.getUTCFullYear()}-${month}`;
+}
+
+function formatMonthSubtitle(month: string): string {
+  const match = /^(\d{4})-(\d{2})$/.exec(month);
+  if (!match) {
+    return month;
+  }
+  const date = new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, 1));
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
 function formatDuration(seconds: number) {
   if (!Number.isFinite(seconds) || seconds <= 0) return "0s";
   const h = Math.floor(seconds / 3600);
@@ -20,38 +39,77 @@ export default function AdminOverview() {
   const [searchInput, setSearchInput] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
   const [jumpPageInput, setJumpPageInput] = useState("");
+  const [monthInput, setMonthInput] = useState(currentMonthValue);
+  const [minDurationInput, setMinDurationInput] = useState("10");
+  const [excludeExtension, setExcludeExtension] = useState(false);
   const limit = 20;
 
-  const load = useCallback(async (targetPage: number, targetSearch: string) => {
-    setLoading(true);
-    setError(null);
-    const res = await adminFetchUsersOverview({
-      page: targetPage,
-      limit,
-      search: targetSearch,
-    });
-    if (!res.ok || !res.data) {
-      setOverview(null);
-      setError(res.error ?? "Failed to load admin overview");
+  const load = useCallback(
+    async (
+      targetPage: number,
+      targetSearch: string,
+      month: string,
+      minDuration: string,
+      excludeIosExtension: boolean,
+    ) => {
+      setLoading(true);
+      setError(null);
+
+      const parsedMin = Number(minDuration);
+      if (!Number.isInteger(parsedMin) || parsedMin < 0) {
+        setOverview(null);
+        setError("Min duration must be a non-negative whole number");
+        setLoading(false);
+        return;
+      }
+
+      const res = await adminFetchUsersOverview({
+        page: targetPage,
+        limit,
+        search: targetSearch,
+        month,
+        minDurationSeconds: parsedMin,
+        excludePlatforms: excludeIosExtension ? "ios_extension" : undefined,
+      });
+      if (!res.ok || !res.data) {
+        setOverview(null);
+        setError(res.error ?? "Failed to load admin overview");
+        setLoading(false);
+        return;
+      }
+      setOverview(res.data);
+      setPage(res.data.page);
       setLoading(false);
-      return;
-    }
-    setOverview(res.data);
-    setPage(res.data.page);
-    setLoading(false);
-  }, [limit]);
+    },
+    [limit],
+  );
 
   useEffect(() => {
-    void load(1, searchTerm);
+    void load(1, searchTerm, currentMonthValue(), "10", false);
   }, [load]);
+
+  const applyFilters = () => {
+    void load(page, searchTerm, monthInput, minDurationInput, excludeExtension);
+  };
+
+  const activeMonth = overview?.month ?? monthInput;
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold">Overview</h2>
+        <div>
+          <h2 className="text-2xl font-bold">Overview</h2>
+          <p className="mt-1 text-sm text-foreground/85">
+            User list with VPN session counts for the selected month (UTC).
+            Use the same month and filters as Connection engagement to reconcile
+            totals.
+          </p>
+        </div>
         <button
           type="button"
-          onClick={() => void load(page, searchTerm)}
+          onClick={() =>
+            void load(page, searchTerm, monthInput, minDurationInput, excludeExtension)
+          }
           className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
         >
           Refresh
@@ -69,6 +127,49 @@ export default function AdminOverview() {
         <p className="mt-1 text-3xl font-semibold">{overview?.totalUsers ?? (loading ? "…" : 0)}</p>
       </div>
 
+      <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border p-4">
+        <label className="text-sm">
+          <span className="mb-1 block text-muted-foreground">Month (UTC)</span>
+          <input
+            type="month"
+            value={monthInput}
+            onChange={(event) => setMonthInput(event.target.value)}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            Min duration (seconds)
+          </span>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            value={minDurationInput}
+            onChange={(event) => setMinDurationInput(event.target.value)}
+            className="w-28 rounded-md border border-border bg-background px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="flex items-center gap-2 pb-2 text-sm">
+          <input
+            type="checkbox"
+            checked={excludeExtension}
+            onChange={(event) => setExcludeExtension(event.target.checked)}
+            className="rounded border-border"
+          />
+          <span className="text-muted-foreground">
+            Exclude iOS extension rows
+          </span>
+        </label>
+        <button
+          type="button"
+          onClick={applyFilters}
+          className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
+        >
+          Apply
+        </button>
+      </div>
+
       <div className="flex flex-wrap items-end gap-2">
         <label className="text-sm">
           <span className="mb-1 block text-muted-foreground">Search users</span>
@@ -84,7 +185,7 @@ export default function AdminOverview() {
           onClick={() => {
             const trimmed = searchInput.trim();
             setSearchTerm(trimmed);
-            void load(1, trimmed);
+            void load(1, trimmed, monthInput, minDurationInput, excludeExtension);
           }}
           className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
         >
@@ -95,7 +196,7 @@ export default function AdminOverview() {
           onClick={() => {
             setSearchInput("");
             setSearchTerm("");
-            void load(1, "");
+            void load(1, "", monthInput, minDurationInput, excludeExtension);
           }}
           className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
         >
@@ -105,12 +206,18 @@ export default function AdminOverview() {
 
       <div className="rounded-lg border border-border overflow-x-auto">
         <div className="border-b border-border bg-muted/40 px-4 py-3 text-sm font-medium">
-          Users by longest session
+          Users by longest session ({formatMonthSubtitle(activeMonth)})
+          <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+            Connections and longest session use effective duration (same as the
+            session detail view), min{" "}
+            {overview?.filters.min_duration_seconds ?? minDurationInput}s
+          </span>
         </div>
-        <table className="w-full min-w-[640px] text-sm">
+        <table className="w-full min-w-[720px] text-sm">
           <thead className="bg-muted/50">
             <tr className="text-left">
               <th className="p-3">User</th>
+              <th className="p-3 text-right">Connections</th>
               <th className="p-3">Longest session</th>
               <th className="p-3">Joined</th>
               <th className="p-3">Sessions</th>
@@ -120,6 +227,9 @@ export default function AdminOverview() {
             {(overview?.users ?? []).map((u) => (
               <tr key={u.id} className="border-t border-border">
                 <td className="p-3">{u.name ? `${u.name} (${u.email})` : u.email}</td>
+                <td className="p-3 text-right font-mono tabular-nums">
+                  {u.connectionCount}
+                </td>
                 <td className="p-3 font-mono">{formatDuration(u.longestSessionSeconds)}</td>
                 <td className="p-3 text-muted-foreground">{u.createdAt.slice(0, 10)}</td>
                 <td className="p-3">
@@ -134,7 +244,7 @@ export default function AdminOverview() {
             ))}
             {!loading && (overview?.users.length ?? 0) === 0 ? (
               <tr>
-                <td className="p-4 text-muted-foreground" colSpan={4}>
+                <td className="p-4 text-muted-foreground" colSpan={5}>
                   No users found.
                 </td>
               </tr>
@@ -160,7 +270,13 @@ export default function AdminOverview() {
               const requested = Number.parseInt(jumpPageInput, 10);
               if (!Number.isFinite(requested) || requested < 1) return;
               const maxPage = overview?.totalPages ?? 1;
-              void load(Math.min(requested, maxPage), searchTerm);
+              void load(
+                Math.min(requested, maxPage),
+                searchTerm,
+                monthInput,
+                minDurationInput,
+                excludeExtension,
+              );
             }}
             className="rounded-md border border-border px-3 py-1.5 hover:bg-muted"
           >
@@ -168,7 +284,15 @@ export default function AdminOverview() {
           </button>
           <button
             type="button"
-            onClick={() => void load(Math.max(1, page - 1), searchTerm)}
+            onClick={() =>
+              void load(
+                Math.max(1, page - 1),
+                searchTerm,
+                monthInput,
+                minDurationInput,
+                excludeExtension,
+              )
+            }
             disabled={loading || page <= 1}
             className="rounded-md border border-border px-3 py-1.5 hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -176,7 +300,15 @@ export default function AdminOverview() {
           </button>
           <button
             type="button"
-            onClick={() => void load(page + 1, searchTerm)}
+            onClick={() =>
+              void load(
+                page + 1,
+                searchTerm,
+                monthInput,
+                minDurationInput,
+                excludeExtension,
+              )
+            }
             disabled={loading || page >= (overview?.totalPages ?? 1)}
             className="rounded-md border border-border px-3 py-1.5 hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
           >


### PR DESCRIPTION
Let admins reconcile overview data with connection engagement using shared month, duration, and platform filters plus per-user connection counts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->