### PR TITLE
Add UTM attribution capture and admin dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
+import UtmCapture from "@/components/UtmCapture";
 import ProtectedRoute from "@/components/ProtectedRoute";
 import AdminProtectedRoute from "@/components/admin/AdminProtectedRoute";
 import AdminSidebarLayout from "@/components/admin/AdminSidebarLayout";
@@ -60,6 +61,9 @@ const AdminUsers = lazy(() => import("./pages/admin/AdminUsers"));
 const AdminUserSessions = lazy(
   () => import("./pages/admin/AdminUserSessions"),
 );
+const AdminUtmAttribution = lazy(
+  () => import("./pages/admin/AdminUtmAttribution"),
+);
 
 const queryClient = new QueryClient();
 
@@ -76,6 +80,7 @@ const App = () => (
         <Toaster />
         <Sonner />
         <BrowserRouter>
+          <UtmCapture />
           <Suspense fallback={<PageLoader />}>
             <Routes>
               <Route path="/" element={<Index />} />
@@ -184,6 +189,7 @@ const App = () => (
                 <Route path="subscriptions" element={<AdminSubscriptions />} />
                 <Route path="churn" element={<AdminChurn />} />
                 <Route path="users" element={<AdminUsers />} />
+                <Route path="utm-attribution" element={<AdminUtmAttribution />} />
               </Route>
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -597,6 +597,7 @@ export async function verifyMagicLink(
       body: JSON.stringify({
         token,
         ...(referralToken ? { referralToken } : {}),
+        ...getUtmAttributionAuthPayload(),
       }),
     });
     const data: unknown = await response.json().catch(() => ({}));
@@ -613,6 +614,7 @@ export async function verifyMagicLink(
     });
     if (normalized.success ?? true) {
       clearReferralTokenStorage();
+      clearUtmAttributionStorage();
     }
     return normalized;
   } catch (error) {
@@ -2304,8 +2306,8 @@ export async function adminFetchUtmSignupReport(params?: {
         error: extractBackendErrorMessage(data, "Failed to load UTM sign-up report"),
       };
     }
-    const record = data as { success?: boolean; data?: AdminUtmSignupReport };
-    if (!record.success || !record.data) {
+    const record = data as { data?: AdminUtmSignupReport };
+    if (!record.data) {
       return { ok: false, error: "Invalid UTM sign-up report response" };
     }
     return { ok: true, data: record.data };

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -4,6 +4,10 @@ import {
   getReferralTokenFromStorage,
   clearReferralTokenStorage,
 } from "./referral-token";
+import {
+  clearUtmAttributionStorage,
+  getUtmAttributionAuthPayload,
+} from "@/lib/utm-attribution";
 
 export const BACKEND_URL =
   import.meta.env.VITE_BACKEND_URL || "/api";
@@ -193,6 +197,7 @@ export async function loginWithFirebaseToken(
         idToken,
         ...(provider ? { provider } : {}),
         ...(referralToken ? { referralToken } : {}),
+        ...getUtmAttributionAuthPayload(),
       }),
     });
     const data: unknown = await response.json().catch(() => ({}));
@@ -204,6 +209,7 @@ export async function loginWithFirebaseToken(
     const normalized = normalizeBackendAuthResponse(data as RawBackendAuthResponse);
     if (normalized.success ?? true) {
       clearReferralTokenStorage();
+      clearUtmAttributionStorage();
     }
     return { ...normalized, success: normalized.success ?? true };
   } catch (error) {
@@ -233,6 +239,7 @@ export async function authenticateWithBackend(
     const referralToken = getReferralTokenFromStorage();
     const endpoint =
       provider === "apple" ? "/auth/apple/signin" : "/auth/google/signin";
+    const utmPayload = getUtmAttributionAuthPayload();
     const body =
       provider === "apple"
         ? {
@@ -241,10 +248,12 @@ export async function authenticateWithBackend(
             email: additionalData?.email,
             fullName: additionalData?.fullName,
             ...(referralToken ? { referralToken } : {}),
+            ...utmPayload,
           }
         : {
             idToken: accessToken, // Backend expects 'idToken' parameter for Google
             ...(referralToken ? { referralToken } : {}),
+            ...utmPayload,
           };
 
     const response = await fetch(`${BACKEND_URL}${endpoint}`, {
@@ -267,6 +276,7 @@ export async function authenticateWithBackend(
     const normalized = normalizeBackendAuthResponse(data as RawBackendAuthResponse);
     if (normalized.success ?? true) {
       clearReferralTokenStorage();
+      clearUtmAttributionStorage();
     }
     return { ...normalized, success: normalized.success ?? true };
   } catch (error) {
@@ -891,6 +901,7 @@ export async function verifyEmailOtp(
         email,
         code,
         ...(referralToken ? { referralToken } : {}),
+        ...getUtmAttributionAuthPayload(),
       }),
     });
     const data: unknown = await response.json().catch(() => ({}));
@@ -907,6 +918,7 @@ export async function verifyEmailOtp(
     });
     if (normalized.success ?? true) {
       clearReferralTokenStorage();
+      clearUtmAttributionStorage();
     }
     return { ...normalized, success: normalized.success ?? true };
   } catch (error) {
@@ -2242,6 +2254,65 @@ export async function adminFetchMedianMonthlySessions(params?: {
     const record = raw as { data?: AdminMedianMonthlySessionsReport };
     return { ok: true, data: record.data };
   } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Network error",
+    };
+  }
+}
+
+export interface AdminUtmSignupRow {
+  utm_source: string;
+  utm_medium: string;
+  utm_campaign: string;
+  signups: number;
+}
+
+export interface AdminUtmSignupReport {
+  from: string;
+  to: string;
+  total_signups: number;
+  rows: AdminUtmSignupRow[];
+}
+
+export async function adminFetchUtmSignupReport(params?: {
+  from?: string;
+  to?: string;
+  signal?: AbortSignal;
+}): Promise<{
+  ok: boolean;
+  data?: AdminUtmSignupReport;
+  error?: string;
+}> {
+  try {
+    const query = new URLSearchParams();
+    if (params?.from) query.set("from", params.from);
+    if (params?.to) query.set("to", params.to);
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    const response = await fetch(
+      `${BACKEND_URL}/admin/utm-attribution/signups${suffix}`,
+      {
+        method: "GET",
+        credentials: "include",
+        signal: params?.signal,
+      },
+    );
+    const data: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(data, "Failed to load UTM sign-up report"),
+      };
+    }
+    const record = data as { success?: boolean; data?: AdminUtmSignupReport };
+    if (!record.success || !record.data) {
+      return { ok: false, error: "Invalid UTM sign-up report response" };
+    }
+    return { ok: true, data: record.data };
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") {
+      return { ok: false, error: "Request aborted" };
+    }
     return {
       ok: false,
       error: e instanceof Error ? e.message : "Network error",

--- a/src/components/UtmCapture.tsx
+++ b/src/components/UtmCapture.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+import { captureUtmFromSearch } from "@/lib/utm-attribution";
+
+/** Persists first-touch UTM params from the landing URL across the sign-up flow. */
+export default function UtmCapture() {
+  const location = useLocation();
+
+  useEffect(() => {
+    captureUtmFromSearch(location.search, location.pathname);
+  }, [location.pathname, location.search]);
+
+  return null;
+}

--- a/src/components/admin/AdminSidebarLayout.tsx
+++ b/src/components/admin/AdminSidebarLayout.tsx
@@ -13,6 +13,7 @@ import {
   TrendingDown,
   Mail,
   Gift,
+  Megaphone,
 } from "lucide-react";
 
 function linkClass(isActive: boolean) {
@@ -105,6 +106,13 @@ export default function AdminSidebarLayout() {
             >
               <TrendingDown className="h-4 w-4" />
               Churn
+            </NavLink>
+            <NavLink
+              to="/admin/utm-attribution"
+              className={({ isActive }) => linkClass(isActive)}
+            >
+              <Megaphone className="h-4 w-4" />
+              UTM Attribution
             </NavLink>
             <NavLink
               to="/admin/users"

--- a/src/lib/utm-attribution.ts
+++ b/src/lib/utm-attribution.ts
@@ -1,0 +1,92 @@
+export const UTM_ATTRIBUTION_STORAGE_KEY = "keen_utm_attribution";
+
+export interface StoredUtmAttribution {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
+  landing_path: string;
+  captured_at: string;
+}
+
+const UTM_PARAM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+] as const;
+
+function trimParam(value: string | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, 500) : undefined;
+}
+
+export function getStoredUtmAttribution(): StoredUtmAttribution | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(UTM_ATTRIBUTION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredUtmAttribution;
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function setStoredUtmAttribution(value: StoredUtmAttribution): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(UTM_ATTRIBUTION_STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    /* private mode / blocked storage */
+  }
+}
+
+export function clearUtmAttributionStorage(): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(UTM_ATTRIBUTION_STORAGE_KEY);
+  } catch {
+    /* private mode / blocked storage */
+  }
+}
+
+/** First-touch capture: only stores the first UTM set seen in this browser. */
+export function captureUtmFromSearch(
+  search: string,
+  landingPath: string,
+): void {
+  if (typeof window === "undefined") return;
+  if (getStoredUtmAttribution()) return;
+
+  const params = new URLSearchParams(
+    search.startsWith("?") ? search : `?${search}`,
+  );
+  const captured: StoredUtmAttribution = {
+    landing_path: landingPath.slice(0, 500),
+    captured_at: new Date().toISOString(),
+  };
+
+  let hasUtm = false;
+  for (const key of UTM_PARAM_KEYS) {
+    const value = trimParam(params.get(key));
+    if (value) {
+      captured[key] = value;
+      hasUtm = true;
+    }
+  }
+
+  if (!hasUtm) return;
+  setStoredUtmAttribution(captured);
+}
+
+export function getUtmAttributionAuthPayload():
+  | { utmAttribution: StoredUtmAttribution }
+  | Record<string, never> {
+  const stored = getStoredUtmAttribution();
+  if (!stored) return {};
+  return { utmAttribution: stored };
+}

--- a/src/lib/utm-attribution.ts
+++ b/src/lib/utm-attribution.ts
@@ -10,6 +10,10 @@ export interface StoredUtmAttribution {
   captured_at: string;
 }
 
+export interface UtmAttributionAuthPayload {
+  utmAttribution?: StoredUtmAttribution;
+}
+
 const UTM_PARAM_KEYS = [
   "utm_source",
   "utm_medium",
@@ -23,13 +27,35 @@ function trimParam(value: string | null): string | undefined {
   return trimmed ? trimmed.slice(0, 500) : undefined;
 }
 
+function hasStoredUtmValue(record: StoredUtmAttribution): boolean {
+  return UTM_PARAM_KEYS.some((key) => Boolean(record[key]?.trim()));
+}
+
+function isValidStoredUtmAttribution(
+  value: unknown,
+): value is StoredUtmAttribution {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  if (typeof record.landing_path !== "string" || !record.landing_path.trim()) {
+    return false;
+  }
+  if (typeof record.captured_at !== "string" || !record.captured_at.trim()) {
+    return false;
+  }
+  const normalized = record as StoredUtmAttribution;
+  return hasStoredUtmValue(normalized);
+}
+
 export function getStoredUtmAttribution(): StoredUtmAttribution | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = localStorage.getItem(UTM_ATTRIBUTION_STORAGE_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as StoredUtmAttribution;
-    if (!parsed || typeof parsed !== "object") return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidStoredUtmAttribution(parsed)) {
+      localStorage.removeItem(UTM_ATTRIBUTION_STORAGE_KEY);
+      return null;
+    }
     return parsed;
   } catch {
     return null;
@@ -62,9 +88,7 @@ export function captureUtmFromSearch(
   if (typeof window === "undefined") return;
   if (getStoredUtmAttribution()) return;
 
-  const params = new URLSearchParams(
-    search.startsWith("?") ? search : `?${search}`,
-  );
+  const params = new URLSearchParams(search);
   const captured: StoredUtmAttribution = {
     landing_path: landingPath.slice(0, 500),
     captured_at: new Date().toISOString(),
@@ -83,9 +107,7 @@ export function captureUtmFromSearch(
   setStoredUtmAttribution(captured);
 }
 
-export function getUtmAttributionAuthPayload():
-  | { utmAttribution: StoredUtmAttribution }
-  | Record<string, never> {
+export function getUtmAttributionAuthPayload(): UtmAttributionAuthPayload {
   const stored = getStoredUtmAttribution();
   if (!stored) return {};
   return { utmAttribution: stored };

--- a/src/pages/admin/AdminUtmAttribution.tsx
+++ b/src/pages/admin/AdminUtmAttribution.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  adminFetchUtmSignupReport,
+  type AdminUtmSignupReport,
+} from "@/auth/backend";
+
+function defaultFromValue(): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() - 30);
+  return date.toISOString().slice(0, 10);
+}
+
+function defaultToValue(): string {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString().slice(0, 10);
+}
+
+export default function AdminUtmAttribution() {
+  const [fromInput, setFromInput] = useState(defaultFromValue);
+  const [toInput, setToInput] = useState(defaultToValue);
+  const [report, setReport] = useState<AdminUtmSignupReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const activeRequest = useRef<AbortController | null>(null);
+
+  const load = useCallback(async (from: string, to: string) => {
+    activeRequest.current?.abort();
+    const controller = new AbortController();
+    activeRequest.current = controller;
+
+    setLoading(true);
+    setError(null);
+
+    const res = await adminFetchUtmSignupReport({
+      from: `${from}T00:00:00.000Z`,
+      to: `${to}T00:00:00.000Z`,
+      signal: controller.signal,
+    });
+
+    if (controller.signal.aborted || activeRequest.current !== controller) {
+      return;
+    }
+
+    if (!res.ok || !res.data) {
+      setReport(null);
+      setError(res.error ?? "Failed to load UTM sign-up report");
+      setLoading(false);
+      activeRequest.current = null;
+      return;
+    }
+
+    setReport(res.data);
+    setLoading(false);
+    activeRequest.current = null;
+  }, []);
+
+  useEffect(() => {
+    void load(fromInput, toInput);
+    return () => activeRequest.current?.abort();
+  }, [load, fromInput, toInput]);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">UTM attribution</h2>
+        <p className="text-sm text-muted-foreground">
+          First-touch sign-ups grouped by UTM source, campaign, and medium.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-muted-foreground">From (UTC)</span>
+          <input
+            type="date"
+            className="rounded-md border border-border bg-background px-3 py-2"
+            value={fromInput}
+            onChange={(e) => setFromInput(e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-muted-foreground">To (UTC, exclusive)</span>
+          <input
+            type="date"
+            className="rounded-md border border-border bg-background px-3 py-2"
+            value={toInput}
+            onChange={(e) => setToInput(e.target.value)}
+          />
+        </label>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={loading}
+          onClick={() => void load(fromInput, toInput)}
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="rounded-lg border border-border bg-card p-4">
+        <p className="text-sm text-muted-foreground">
+          Total attributed sign-ups
+        </p>
+        <p className="text-3xl font-semibold">
+          {loading ? "—" : (report?.total_signups ?? 0)}
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-border overflow-x-auto">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead className="bg-muted/50">
+            <tr className="text-left">
+              <th className="p-3">UTM source</th>
+              <th className="p-3">UTM campaign</th>
+              <th className="p-3">UTM medium</th>
+              <th className="p-3 text-right">Sign-ups</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td className="p-3 text-muted-foreground" colSpan={4}>
+                  Loading…
+                </td>
+              </tr>
+            ) : null}
+            {!loading && (report?.rows.length ?? 0) === 0 ? (
+              <tr>
+                <td className="p-3 text-muted-foreground" colSpan={4}>
+                  No attributed sign-ups in this range.
+                </td>
+              </tr>
+            ) : null}
+            {!loading
+              ? (report?.rows ?? []).map((row) => (
+                  <tr key={`${row.utm_source}-${row.utm_campaign}-${row.utm_medium}`} className="border-t border-border">
+                    <td className="p-3">{row.utm_source}</td>
+                    <td className="p-3">{row.utm_campaign}</td>
+                    <td className="p-3">{row.utm_medium}</td>
+                    <td className="p-3 text-right">{row.signups}</td>
+                  </tr>
+                ))
+              : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/AdminUtmAttribution.tsx
+++ b/src/pages/admin/AdminUtmAttribution.tsx
@@ -140,8 +140,11 @@ export default function AdminUtmAttribution() {
               </tr>
             ) : null}
             {!loading
-              ? (report?.rows ?? []).map((row) => (
-                  <tr key={`${row.utm_source}-${row.utm_campaign}-${row.utm_medium}`} className="border-t border-border">
+              ? (report?.rows ?? []).map((row, index) => (
+                  <tr
+                    key={`${index}\u0000${row.utm_source}\u0000${row.utm_campaign}\u0000${row.utm_medium}`}
+                    className="border-t border-border"
+                  >
                     <td className="p-3">{row.utm_source}</td>
                     <td className="p-3">{row.utm_campaign}</td>
                     <td className="p-3">{row.utm_medium}</td>


### PR DESCRIPTION
## Summary
- Capture first-touch UTM params in the browser and send them with web sign-up requests
- Clear stored UTMs after successful authentication
- Add admin page `/admin/utm-attribution` with sign-up counts by source, campaign, and medium

## Test plan
- [ ] Land on site with UTM query params before sign-up
- [ ] Complete web sign-up and confirm backend stores attribution
- [ ] Open Admin → UTM Attribution and verify counts for the test campaign
- [ ] Confirm no Mac/iOS app changes are required for this flow


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/163" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->