### PR TITLE
Add UTM funnel tracking and expand admin attribution dashboard

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -2277,6 +2277,96 @@ export interface AdminUtmSignupReport {
   rows: AdminUtmSignupRow[];
 }
 
+/** Fire-and-forget: records signup_started with stored first-touch UTMs (pre-account). */
+export async function recordSignupStarted(): Promise<void> {
+  const payload = getUtmAttributionAuthPayload();
+  if (!payload.utmAttribution) return;
+  try {
+    await fetch(`${BACKEND_URL}/marketing-attribution/signup-started`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    /* non-fatal */
+  }
+}
+
+export interface AdminUtmFunnelRow {
+  utm_source: string;
+  utm_medium: string;
+  utm_campaign: string;
+  signup_started: number;
+  signups_completed: number;
+  trials: number;
+  subscriptions: number;
+  revenue: number;
+  signup_to_completed_rate: number;
+  signup_to_trial_rate: number;
+  signup_to_paid_rate: number;
+}
+
+export interface AdminUtmFunnelReport {
+  from: string;
+  to: string;
+  totals: {
+    signup_started: number;
+    signups_completed: number;
+    trials: number;
+    subscriptions: number;
+    revenue: number;
+    signup_to_completed_rate: number;
+    signup_to_trial_rate: number;
+    signup_to_paid_rate: number;
+  };
+  rows: AdminUtmFunnelRow[];
+}
+
+export async function adminFetchUtmFunnelReport(params?: {
+  from?: string;
+  to?: string;
+  signal?: AbortSignal;
+}): Promise<{
+  ok: boolean;
+  data?: AdminUtmFunnelReport;
+  error?: string;
+}> {
+  try {
+    const query = new URLSearchParams();
+    if (params?.from) query.set("from", params.from);
+    if (params?.to) query.set("to", params.to);
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    const response = await fetch(
+      `${BACKEND_URL}/admin/utm-attribution/funnel${suffix}`,
+      {
+        method: "GET",
+        credentials: "include",
+        signal: params?.signal,
+      },
+    );
+    const data: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(data, "Failed to load UTM funnel report"),
+      };
+    }
+    const record = data as { data?: AdminUtmFunnelReport };
+    if (!record.data) {
+      return { ok: false, error: "Invalid UTM funnel report response" };
+    }
+    return { ok: true, data: record.data };
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") {
+      return { ok: false, error: "Request aborted" };
+    }
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Network error",
+    };
+  }
+}
+
 export async function adminFetchUtmSignupReport(params?: {
   from?: string;
   to?: string;

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -2277,15 +2277,28 @@ export interface AdminUtmSignupReport {
   rows: AdminUtmSignupRow[];
 }
 
+const SIGNUP_STARTED_SESSION_KEY = "keen_signup_started_tracked";
+
 /** Fire-and-forget: records signup_started with stored first-touch UTMs (pre-account). */
 export async function recordSignupStarted(): Promise<void> {
   const payload = getUtmAttributionAuthPayload();
   if (!payload.utmAttribution) return;
+
+  if (typeof window !== "undefined") {
+    try {
+      if (sessionStorage.getItem(SIGNUP_STARTED_SESSION_KEY)) return;
+      sessionStorage.setItem(SIGNUP_STARTED_SESSION_KEY, "1");
+    } catch {
+      /* private mode / blocked storage */
+    }
+  }
+
   try {
     await fetch(`${BACKEND_URL}/marketing-attribution/signup-started`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
+      keepalive: true,
     });
   } catch {
     /* non-fatal */

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -2287,19 +2287,30 @@ export async function recordSignupStarted(): Promise<void> {
   if (typeof window !== "undefined") {
     try {
       if (sessionStorage.getItem(SIGNUP_STARTED_SESSION_KEY)) return;
-      sessionStorage.setItem(SIGNUP_STARTED_SESSION_KEY, "1");
     } catch {
       /* private mode / blocked storage */
     }
   }
 
   try {
-    await fetch(`${BACKEND_URL}/marketing-attribution/signup-started`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      keepalive: true,
-    });
+    const response = await fetch(
+      `${BACKEND_URL}/marketing-attribution/signup-started`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        keepalive: true,
+      },
+    );
+    if (!response.ok) return;
+
+    if (typeof window !== "undefined") {
+      try {
+        sessionStorage.setItem(SIGNUP_STARTED_SESSION_KEY, "1");
+      } catch {
+        /* private mode / blocked storage */
+      }
+    }
   } catch {
     /* non-fatal */
   }

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -2279,6 +2279,8 @@ export interface AdminUtmSignupReport {
 
 const SIGNUP_STARTED_SESSION_KEY = "keen_signup_started_tracked";
 
+let signupStartedInFlight: Promise<void> | null = null;
+
 /** Fire-and-forget: records signup_started with stored first-touch UTMs (pre-account). */
 export async function recordSignupStarted(): Promise<void> {
   const payload = getUtmAttributionAuthPayload();
@@ -2292,28 +2294,38 @@ export async function recordSignupStarted(): Promise<void> {
     }
   }
 
-  try {
-    const response = await fetch(
-      `${BACKEND_URL}/marketing-attribution/signup-started`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-        keepalive: true,
-      },
-    );
-    if (!response.ok) return;
-
-    if (typeof window !== "undefined") {
-      try {
-        sessionStorage.setItem(SIGNUP_STARTED_SESSION_KEY, "1");
-      } catch {
-        /* private mode / blocked storage */
-      }
-    }
-  } catch {
-    /* non-fatal */
+  if (signupStartedInFlight) {
+    return signupStartedInFlight;
   }
+
+  signupStartedInFlight = (async () => {
+    try {
+      const response = await fetch(
+        `${BACKEND_URL}/marketing-attribution/signup-started`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          keepalive: true,
+        },
+      );
+      if (!response.ok) return;
+
+      if (typeof window !== "undefined") {
+        try {
+          sessionStorage.setItem(SIGNUP_STARTED_SESSION_KEY, "1");
+        } catch {
+          /* private mode / blocked storage */
+        }
+      }
+    } catch {
+      /* non-fatal */
+    } finally {
+      signupStartedInFlight = null;
+    }
+  })();
+
+  return signupStartedInFlight;
 }
 
 export interface AdminUtmFunnelRow {

--- a/src/lib/utm-attribution-export.ts
+++ b/src/lib/utm-attribution-export.ts
@@ -1,0 +1,97 @@
+import type { AdminUtmFunnelReport } from "@/auth/backend";
+
+const SPREADSHEET_FORMULA_PREFIX_RE = /^[=+\-@\t\r]/;
+
+function neutralizeSpreadsheetFormula(text: string): string {
+  const leadingWhitespace = text.match(/^\s*/)?.[0] ?? "";
+  const body = text.slice(leadingWhitespace.length);
+  if (SPREADSHEET_FORMULA_PREFIX_RE.test(body)) {
+    return `${leadingWhitespace}'${body}`;
+  }
+  return text;
+}
+
+function escapeCsvCell(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  const text =
+    typeof value === "string"
+      ? neutralizeSpreadsheetFormula(value)
+      : String(value);
+  if (/[",\n\r]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+function csvRow(cells: (string | number | boolean | null | undefined)[]): string {
+  return cells.map(escapeCsvCell).join(",");
+}
+
+function downloadTextFile(
+  filename: string,
+  content: string,
+  mimeType: string,
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  window.setTimeout(() => {
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }, 100);
+}
+
+export function buildUtmFunnelCsv(report: AdminUtmFunnelReport): string {
+  const lines: string[] = [];
+  lines.push(
+    csvRow([
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "signup_started",
+      "signups_completed",
+      "trials",
+      "subscriptions",
+      "revenue",
+      "signup_to_completed_rate",
+      "signup_to_trial_rate",
+      "signup_to_paid_rate",
+    ]),
+  );
+
+  for (const row of report.rows) {
+    lines.push(
+      csvRow([
+        row.utm_source,
+        row.utm_medium,
+        row.utm_campaign,
+        row.signup_started,
+        row.signups_completed,
+        row.trials,
+        row.subscriptions,
+        row.revenue,
+        row.signup_to_completed_rate,
+        row.signup_to_trial_rate,
+        row.signup_to_paid_rate,
+      ]),
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function downloadUtmFunnelCsv(report: AdminUtmFunnelReport): void {
+  const from = report.from.slice(0, 10);
+  const to = report.to.slice(0, 10);
+  downloadTextFile(
+    `utm-funnel-${from}-to-${to}.csv`,
+    buildUtmFunnelCsv(report),
+    "text/csv;charset=utf-8",
+  );
+}

--- a/src/lib/utm-attribution-export.ts
+++ b/src/lib/utm-attribution-export.ts
@@ -52,8 +52,8 @@ export function buildUtmFunnelCsv(report: AdminUtmFunnelReport): string {
   lines.push(
     csvRow([
       "utm_source",
-      "utm_medium",
       "utm_campaign",
+      "utm_medium",
       "signup_started",
       "signups_completed",
       "trials",
@@ -69,8 +69,8 @@ export function buildUtmFunnelCsv(report: AdminUtmFunnelReport): string {
     lines.push(
       csvRow([
         row.utm_source,
-        row.utm_medium,
         row.utm_campaign,
+        row.utm_medium,
         row.signup_started,
         row.signups_completed,
         row.trials,

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -30,6 +30,7 @@ import {
   useDebounce,
   verifyEmailOtp,
 } from "@/auth";
+import { recordSignupStarted } from "@/auth/backend";
 import GoogleIcon from "@/components/ui/google-icon";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -98,10 +99,12 @@ const SignIn = () => {
 
   // Debounce sign-in to prevent double-clicks
   const [handleGoogleSignIn, isGoogleDebouncing] = useDebounce(async () => {
+    void recordSignupStarted();
     await signIn("google");
   }, 2000);
 
   const [handleAppleSignIn, isAppleDebouncing] = useDebounce(async () => {
+    void recordSignupStarted();
     await signIn("apple");
   }, 2000);
 
@@ -115,6 +118,7 @@ const SignIn = () => {
   const sendOtp = async () => {
     if (!emailForOtp) return;
 
+    void recordSignupStarted();
     setOtpLoading(true);
     setOtpMessage("");
     const result = await requestEmailOtp(emailForOtp);

--- a/src/pages/admin/AdminUtmAttribution.tsx
+++ b/src/pages/admin/AdminUtmAttribution.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
+  adminFetchUtmFunnelReport,
   adminFetchUtmSignupReport,
+  type AdminUtmFunnelReport,
   type AdminUtmSignupReport,
 } from "@/auth/backend";
+import { downloadUtmFunnelCsv } from "@/lib/utm-attribution-export";
 
 function defaultFromValue(): string {
   const date = new Date();
@@ -17,10 +20,28 @@ function defaultToValue(): string {
   return date.toISOString().slice(0, 10);
 }
 
+function formatRate(value: number): string {
+  return `${value.toFixed(2)}%`;
+}
+
+function formatRevenue(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
 export default function AdminUtmAttribution() {
   const [fromInput, setFromInput] = useState(defaultFromValue);
   const [toInput, setToInput] = useState(defaultToValue);
-  const [report, setReport] = useState<AdminUtmSignupReport | null>(null);
+  const [signupReport, setSignupReport] = useState<AdminUtmSignupReport | null>(
+    null,
+  );
+  const [funnelReport, setFunnelReport] = useState<AdminUtmFunnelReport | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const activeRequest = useRef<AbortController | null>(null);
@@ -38,25 +59,41 @@ export default function AdminUtmAttribution() {
     setLoading(true);
     setError(null);
 
-    const res = await adminFetchUtmSignupReport({
-      from: `${from}T00:00:00.000Z`,
-      to: `${to}T00:00:00.000Z`,
-      signal: controller.signal,
-    });
+    const fromIso = `${from}T00:00:00.000Z`;
+    const toIso = `${to}T00:00:00.000Z`;
+
+    const [signupRes, funnelRes] = await Promise.all([
+      adminFetchUtmSignupReport({
+        from: fromIso,
+        to: toIso,
+        signal: controller.signal,
+      }),
+      adminFetchUtmFunnelReport({
+        from: fromIso,
+        to: toIso,
+        signal: controller.signal,
+      }),
+    ]);
 
     if (controller.signal.aborted || activeRequest.current !== controller) {
       return;
     }
 
-    if (!res.ok || !res.data) {
-      setReport(null);
-      setError(res.error ?? "Failed to load UTM sign-up report");
+    if (!signupRes.ok || !signupRes.data || !funnelRes.ok || !funnelRes.data) {
+      setSignupReport(null);
+      setFunnelReport(null);
+      setError(
+        signupRes.error ??
+          funnelRes.error ??
+          "Failed to load UTM attribution reports",
+      );
       setLoading(false);
       activeRequest.current = null;
       return;
     }
 
-    setReport(res.data);
+    setSignupReport(signupRes.data);
+    setFunnelReport(funnelRes.data);
     setLoading(false);
     activeRequest.current = null;
   }, []);
@@ -66,12 +103,15 @@ export default function AdminUtmAttribution() {
     return () => activeRequest.current?.abort();
   }, [load, fromInput, toInput]);
 
+  const totals = funnelReport?.totals;
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <div>
         <h2 className="text-2xl font-semibold tracking-tight">UTM attribution</h2>
         <p className="text-sm text-muted-foreground">
-          First-touch sign-ups grouped by UTM source, campaign, and medium.
+          First-touch sign-ups and conversion funnel by UTM source, campaign, and
+          medium.
         </p>
       </div>
 
@@ -102,6 +142,16 @@ export default function AdminUtmAttribution() {
         >
           Refresh
         </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={loading || !funnelReport}
+          onClick={() => {
+            if (funnelReport) downloadUtmFunnelCsv(funnelReport);
+          }}
+        >
+          Export funnel CSV
+        </Button>
       </div>
 
       {error ? (
@@ -110,55 +160,166 @@ export default function AdminUtmAttribution() {
         </div>
       ) : null}
 
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Sign-up started</p>
+          <p className="text-2xl font-semibold">
+            {loading || error ? "—" : (totals?.signup_started ?? 0)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Attributed sign-ups</p>
+          <p className="text-2xl font-semibold">
+            {loading || error ? "—" : (totals?.signups_completed ?? 0)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Trials</p>
+          <p className="text-2xl font-semibold">
+            {loading || error ? "—" : (totals?.trials ?? 0)}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {loading || error
+              ? ""
+              : formatRate(totals?.signup_to_trial_rate ?? 0) + " of sign-ups"}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-4">
+          <p className="text-sm text-muted-foreground">Paid subscriptions</p>
+          <p className="text-2xl font-semibold">
+            {loading || error ? "—" : (totals?.subscriptions ?? 0)}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {loading || error
+              ? ""
+              : formatRate(totals?.signup_to_paid_rate ?? 0) + " of sign-ups"}
+          </p>
+        </div>
+      </div>
+
       <div className="rounded-lg border border-border bg-card p-4">
-        <p className="text-sm text-muted-foreground">
-          Total attributed sign-ups
-        </p>
+        <p className="text-sm text-muted-foreground">Attributed revenue</p>
         <p className="text-3xl font-semibold">
-          {loading || error ? "—" : (report?.total_signups ?? 0)}
+          {loading || error ? "—" : formatRevenue(totals?.revenue ?? 0)}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Completed rate:{" "}
+          {loading || error
+            ? "—"
+            : formatRate(totals?.signup_to_completed_rate ?? 0)}
         </p>
       </div>
 
-      <div className="rounded-lg border border-border overflow-x-auto">
-        <table className="w-full min-w-[720px] text-sm">
-          <thead className="bg-muted/50">
-            <tr className="text-left">
-              <th className="p-3">UTM source</th>
-              <th className="p-3">UTM campaign</th>
-              <th className="p-3">UTM medium</th>
-              <th className="p-3 text-right">Sign-ups</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              <tr>
-                <td className="p-3 text-muted-foreground" colSpan={4}>
-                  Loading…
-                </td>
+      <div>
+        <h3 className="mb-2 text-lg font-medium">Conversion funnel</h3>
+        <div className="rounded-lg border border-border overflow-x-auto">
+          <table className="w-full min-w-[1100px] text-sm">
+            <thead className="bg-muted/50">
+              <tr className="text-left">
+                <th className="p-3">UTM source</th>
+                <th className="p-3">UTM campaign</th>
+                <th className="p-3">UTM medium</th>
+                <th className="p-3 text-right">Started</th>
+                <th className="p-3 text-right">Sign-ups</th>
+                <th className="p-3 text-right">Trials</th>
+                <th className="p-3 text-right">Paid</th>
+                <th className="p-3 text-right">Revenue</th>
+                <th className="p-3 text-right">→ Sign-up</th>
+                <th className="p-3 text-right">→ Trial</th>
+                <th className="p-3 text-right">→ Paid</th>
               </tr>
-            ) : null}
-            {!loading && !error && (report?.rows.length ?? 0) === 0 ? (
-              <tr>
-                <td className="p-3 text-muted-foreground" colSpan={4}>
-                  No attributed sign-ups in this range.
-                </td>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td className="p-3 text-muted-foreground" colSpan={11}>
+                    Loading…
+                  </td>
+                </tr>
+              ) : null}
+              {!loading && !error && (funnelReport?.rows.length ?? 0) === 0 ? (
+                <tr>
+                  <td className="p-3 text-muted-foreground" colSpan={11}>
+                    No funnel data in this range.
+                  </td>
+                </tr>
+              ) : null}
+              {!loading && !error
+                ? (funnelReport?.rows ?? []).map((row, index) => (
+                    <tr
+                      key={`${index}\u0000${row.utm_source}\u0000${row.utm_campaign}\u0000${row.utm_medium}`}
+                      className="border-t border-border"
+                    >
+                      <td className="p-3">{row.utm_source}</td>
+                      <td className="p-3">{row.utm_campaign}</td>
+                      <td className="p-3">{row.utm_medium}</td>
+                      <td className="p-3 text-right">{row.signup_started}</td>
+                      <td className="p-3 text-right">{row.signups_completed}</td>
+                      <td className="p-3 text-right">{row.trials}</td>
+                      <td className="p-3 text-right">{row.subscriptions}</td>
+                      <td className="p-3 text-right">
+                        {formatRevenue(row.revenue)}
+                      </td>
+                      <td className="p-3 text-right">
+                        {formatRate(row.signup_to_completed_rate)}
+                      </td>
+                      <td className="p-3 text-right">
+                        {formatRate(row.signup_to_trial_rate)}
+                      </td>
+                      <td className="p-3 text-right">
+                        {formatRate(row.signup_to_paid_rate)}
+                      </td>
+                    </tr>
+                  ))
+                : null}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="mb-2 text-lg font-medium">Sign-ups by UTM</h3>
+        <div className="rounded-lg border border-border overflow-x-auto">
+          <table className="w-full min-w-[720px] text-sm">
+            <thead className="bg-muted/50">
+              <tr className="text-left">
+                <th className="p-3">UTM source</th>
+                <th className="p-3">UTM campaign</th>
+                <th className="p-3">UTM medium</th>
+                <th className="p-3 text-right">Sign-ups</th>
               </tr>
-            ) : null}
-            {!loading && !error
-              ? (report?.rows ?? []).map((row, index) => (
-                  <tr
-                    key={`${index}\u0000${row.utm_source}\u0000${row.utm_campaign}\u0000${row.utm_medium}`}
-                    className="border-t border-border"
-                  >
-                    <td className="p-3">{row.utm_source}</td>
-                    <td className="p-3">{row.utm_campaign}</td>
-                    <td className="p-3">{row.utm_medium}</td>
-                    <td className="p-3 text-right">{row.signups}</td>
-                  </tr>
-                ))
-              : null}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td className="p-3 text-muted-foreground" colSpan={4}>
+                    Loading…
+                  </td>
+                </tr>
+              ) : null}
+              {!loading && !error && (signupReport?.rows.length ?? 0) === 0 ? (
+                <tr>
+                  <td className="p-3 text-muted-foreground" colSpan={4}>
+                    No attributed sign-ups in this range.
+                  </td>
+                </tr>
+              ) : null}
+              {!loading && !error
+                ? (signupReport?.rows ?? []).map((row, index) => (
+                    <tr
+                      key={`${index}\u0000${row.utm_source}\u0000${row.utm_campaign}\u0000${row.utm_medium}`}
+                      className="border-t border-border"
+                    >
+                      <td className="p-3">{row.utm_source}</td>
+                      <td className="p-3">{row.utm_campaign}</td>
+                      <td className="p-3">{row.utm_medium}</td>
+                      <td className="p-3 text-right">{row.signups}</td>
+                    </tr>
+                  ))
+                : null}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Record `signup_started` before Google, Apple, and OTP sign-in when first-touch UTMs are stored
- Expand `/admin/utm-attribution` with funnel KPIs, conversion rates, revenue, and CSV export
- Add `adminFetchUtmFunnelReport` client for the new backend funnel endpoint

## Test plan
- [ ] `npm run build` passes
- [ ] Visit sign-in with UTMs and confirm `signup_started` request fires on auth start
- [ ] Load admin UTM page and verify funnel KPIs + table render
- [ ] Export funnel CSV and confirm columns/rates


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->