### PR TITLE
Return to perks after sign-in and clear broadcast form on send

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -103,6 +103,14 @@ export {
 } from './hooks';
 
 export {
+  POST_LOGIN_REDIRECT_PARAM,
+  buildSignInUrl,
+  capturePostLoginRedirectFromSearch,
+  consumePostLoginRedirect,
+  sanitizePostLoginRedirect,
+} from './post-login-redirect';
+
+export {
   RETENTION_WINBACK_TOKEN_STORAGE_KEY,
   clearRetentionWinbackTokenStorage,
   getRetentionWinbackTokenFromStorage,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -106,6 +106,7 @@ export {
   POST_LOGIN_REDIRECT_PARAM,
   buildSignInUrl,
   capturePostLoginRedirectFromSearch,
+  clearPostLoginRedirect,
   consumePostLoginRedirect,
   sanitizePostLoginRedirect,
 } from './post-login-redirect';

--- a/src/auth/post-login-redirect.test.ts
+++ b/src/auth/post-login-redirect.test.ts
@@ -22,24 +22,56 @@ describe("sanitizePostLoginRedirect", () => {
   });
 });
 
+function createStorage() {
+  const values = new Map<string, string>();
+  return {
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+  };
+}
+
 describe("post-login redirect storage", () => {
   it("captures and consumes a redirect from sign-in query params", () => {
-    const storage = {
-      _value: null as string | null,
-      setItem(_key: string, value: string) {
-        this._value = value;
-      },
-      getItem() {
-        return this._value;
-      },
-      removeItem() {
-        this._value = null;
-      },
-    };
+    const storage = createStorage();
 
     capturePostLoginRedirectFromSearch("?redirect=%2Fperks", storage);
     expect(consumePostLoginRedirect(storage)).toBe("/perks");
     expect(consumePostLoginRedirect(storage)).toBeNull();
+  });
+
+  it("clears stale redirect when sign-in has no redirect param", () => {
+    const storage = createStorage();
+    storage.setItem("keenvpn_post_login_redirect", "/perks");
+
+    capturePostLoginRedirectFromSearch("", storage);
+
+    expect(storage.getItem("keenvpn_post_login_redirect")).toBeNull();
+  });
+
+  it("keeps stored redirect during oauth round-trips without query params", () => {
+    const storage = createStorage();
+    storage.setItem("keenvpn_post_login_redirect", "/perks");
+    storage.setItem("auth_redirect_pending", "true");
+
+    capturePostLoginRedirectFromSearch("", storage);
+
+    expect(storage.getItem("keenvpn_post_login_redirect")).toBe("/perks");
+  });
+
+  it("clears redirect when query param is invalid", () => {
+    const storage = createStorage();
+    storage.setItem("keenvpn_post_login_redirect", "/perks");
+
+    capturePostLoginRedirectFromSearch("?redirect=https%3A%2F%2Fevil.com", storage);
+
+    expect(storage.getItem("keenvpn_post_login_redirect")).toBeNull();
   });
 });
 

--- a/src/auth/post-login-redirect.test.ts
+++ b/src/auth/post-login-redirect.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSignInUrl,
+  consumePostLoginRedirect,
+  capturePostLoginRedirectFromSearch,
+  sanitizePostLoginRedirect,
+} from "./post-login-redirect";
+
+describe("sanitizePostLoginRedirect", () => {
+  it("allows internal paths", () => {
+    expect(sanitizePostLoginRedirect("/perks")).toBe("/perks");
+    expect(sanitizePostLoginRedirect("/account?tab=billing")).toBe(
+      "/account?tab=billing",
+    );
+  });
+
+  it("blocks external and auth-loop targets", () => {
+    expect(sanitizePostLoginRedirect("https://evil.com/perks")).toBeNull();
+    expect(sanitizePostLoginRedirect("//evil.com/perks")).toBeNull();
+    expect(sanitizePostLoginRedirect("/signin")).toBeNull();
+    expect(sanitizePostLoginRedirect("/auth/magic")).toBeNull();
+  });
+});
+
+describe("post-login redirect storage", () => {
+  it("captures and consumes a redirect from sign-in query params", () => {
+    const storage = {
+      _value: null as string | null,
+      setItem(_key: string, value: string) {
+        this._value = value;
+      },
+      getItem() {
+        return this._value;
+      },
+      removeItem() {
+        this._value = null;
+      },
+    };
+
+    capturePostLoginRedirectFromSearch("?redirect=%2Fperks", storage);
+    expect(consumePostLoginRedirect(storage)).toBe("/perks");
+    expect(consumePostLoginRedirect(storage)).toBeNull();
+  });
+});
+
+describe("buildSignInUrl", () => {
+  it("includes redirect and asweb params when valid", () => {
+    expect(buildSignInUrl({ redirect: "/perks", asweb: true })).toBe(
+      "/signin?asweb=1&redirect=%2Fperks",
+    );
+  });
+});

--- a/src/auth/post-login-redirect.ts
+++ b/src/auth/post-login-redirect.ts
@@ -1,0 +1,78 @@
+export const POST_LOGIN_REDIRECT_PARAM = "redirect";
+const STORAGE_KEY = "keenvpn_post_login_redirect";
+
+const BLOCKED_PATH_PREFIXES = ["/signin", "/auth"];
+
+export function sanitizePostLoginRedirect(
+  raw: string,
+  origin = "https://vpnkeen.com",
+): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed || !trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    return null;
+  }
+  if (trimmed.includes("://")) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed, origin);
+    if (url.origin !== new URL(origin).origin) {
+      return null;
+    }
+
+    const blocked = BLOCKED_PATH_PREFIXES.some(
+      (prefix) =>
+        url.pathname === prefix || url.pathname.startsWith(`${prefix}/`),
+    );
+    if (blocked) {
+      return null;
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+export function capturePostLoginRedirectFromSearch(
+  search: string,
+  storage: Pick<Storage, "setItem"> = sessionStorage,
+): void {
+  const raw = new URLSearchParams(search).get(POST_LOGIN_REDIRECT_PARAM);
+  if (!raw) return;
+
+  const safe = sanitizePostLoginRedirect(raw);
+  if (safe) {
+    storage.setItem(STORAGE_KEY, safe);
+  }
+}
+
+export function consumePostLoginRedirect(
+  storage: Pick<Storage, "getItem" | "removeItem"> = sessionStorage,
+): string | null {
+  const raw = storage.getItem(STORAGE_KEY);
+  storage.removeItem(STORAGE_KEY);
+  if (!raw) return null;
+  return sanitizePostLoginRedirect(raw);
+}
+
+export function buildSignInUrl(options?: {
+  redirect?: string | null;
+  asweb?: boolean;
+}): string {
+  const params = new URLSearchParams();
+  if (options?.asweb) {
+    params.set("asweb", "1");
+  }
+
+  const safe = options?.redirect
+    ? sanitizePostLoginRedirect(options.redirect)
+    : null;
+  if (safe) {
+    params.set(POST_LOGIN_REDIRECT_PARAM, safe);
+  }
+
+  const query = params.toString();
+  return query ? `/signin?${query}` : "/signin";
+}

--- a/src/auth/post-login-redirect.ts
+++ b/src/auth/post-login-redirect.ts
@@ -1,5 +1,6 @@
 export const POST_LOGIN_REDIRECT_PARAM = "redirect";
 const STORAGE_KEY = "keenvpn_post_login_redirect";
+const AUTH_REDIRECT_PENDING_KEY = "auth_redirect_pending";
 
 const BLOCKED_PATH_PREFIXES = ["/signin", "/auth"];
 
@@ -35,17 +36,32 @@ export function sanitizePostLoginRedirect(
   }
 }
 
+export function clearPostLoginRedirect(
+  storage: Pick<Storage, "removeItem"> = sessionStorage,
+): void {
+  storage.removeItem(STORAGE_KEY);
+}
+
 export function capturePostLoginRedirectFromSearch(
   search: string,
-  storage: Pick<Storage, "setItem"> = sessionStorage,
+  storage: Pick<Storage, "setItem" | "removeItem" | "getItem"> = sessionStorage,
 ): void {
   const raw = new URLSearchParams(search).get(POST_LOGIN_REDIRECT_PARAM);
-  if (!raw) return;
+  if (!raw) {
+    // Keep stored redirect during OAuth round-trips that drop query params.
+    if (storage.getItem(AUTH_REDIRECT_PENDING_KEY) !== "true") {
+      storage.removeItem(STORAGE_KEY);
+    }
+    return;
+  }
 
   const safe = sanitizePostLoginRedirect(raw);
   if (safe) {
     storage.setItem(STORAGE_KEY, safe);
+    return;
   }
+
+  storage.removeItem(STORAGE_KEY);
 }
 
 export function consumePostLoginRedirect(

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from "@/contexts/AuthContext";
+import { buildSignInUrl } from "@/auth";
 import { Loader2 } from 'lucide-react';
 
 interface ProtectedRouteProps {
@@ -34,7 +35,13 @@ const ProtectedRoute = ({ children, requireSubscription = false }: ProtectedRout
   }
 
   if (!user) {
-    return <Navigate to={isASWeb ? "/signin?asweb=1" : "/signin"} replace />;
+    const redirectTarget = `${location.pathname}${location.search}${location.hash}`;
+    return (
+      <Navigate
+        to={buildSignInUrl({ redirect: redirectTarget, asweb: isASWeb })}
+        replace
+      />
+    );
   }
 
   if (requireSubscription && (!subscription || subscription.status !== 'active')) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -29,7 +29,10 @@ import {
   consumePendingMembershipTransfer,
   consumePendingMembershipTransferReturnUrl,
 } from "@/auth/membership-transfer-flow";
-import { consumePostLoginRedirect } from "@/auth/post-login-redirect";
+import {
+  clearPostLoginRedirect,
+  consumePostLoginRedirect,
+} from "@/auth/post-login-redirect";
 import { clearStripeCheckoutReturn } from "@/lib/keenvpn-deep-links";
 
 // ============================================================================
@@ -123,6 +126,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       // redirects (win-back token + membership transfer) so they cannot hijack ASWeb.
       consumePendingMembershipTransfer();
       clearRetentionWinbackTokenStorage();
+      clearPostLoginRedirect();
       return '/account?asweb=1';
     }
     if (sessionStorage.getItem(RETENTION_WINBACK_TOKEN_STORAGE_KEY)) {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -29,6 +29,7 @@ import {
   consumePendingMembershipTransfer,
   consumePendingMembershipTransferReturnUrl,
 } from "@/auth/membership-transfer-flow";
+import { consumePostLoginRedirect } from "@/auth/post-login-redirect";
 import { clearStripeCheckoutReturn } from "@/lib/keenvpn-deep-links";
 
 // ============================================================================
@@ -130,6 +131,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const transferUrl = consumePendingMembershipTransferReturnUrl();
     if (transferUrl) {
       return transferUrl;
+    }
+    const redirectUrl = consumePostLoginRedirect();
+    if (redirectUrl) {
+      return redirectUrl;
     }
     return accountUrl();
   }, [accountUrl, isASWebSession]);

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/auth/membership-transfer-flow";
 import {
   capturePostLoginRedirectFromSearch,
+  clearPostLoginRedirect,
   clearRetentionWinbackTokenStorage,
   consumePostLoginRedirect,
   requestEmailOtp,
@@ -68,6 +69,7 @@ const SignIn = () => {
       // can surprise the user on a later full-browser login.
       consumePendingMembershipTransfer();
       clearRetentionWinbackTokenStorage();
+      clearPostLoginRedirect();
       return "/account?asweb=1";
     }
     if (sessionStorage.getItem(RETENTION_WINBACK_TOKEN_STORAGE_KEY)) {

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -23,7 +23,9 @@ import {
   consumePendingMembershipTransferReturnUrl,
 } from "@/auth/membership-transfer-flow";
 import {
+  capturePostLoginRedirectFromSearch,
   clearRetentionWinbackTokenStorage,
+  consumePostLoginRedirect,
   requestEmailOtp,
   RETENTION_WINBACK_TOKEN_STORAGE_KEY,
   storeSessionToken,
@@ -49,6 +51,11 @@ const SignIn = () => {
   const [otpLoading, setOtpLoading] = React.useState(false);
 
   const emailForOtp = otpEmail.trim().toLowerCase();
+
+  React.useEffect(() => {
+    capturePostLoginRedirectFromSearch(window.location.search);
+  }, []);
+
   const postOtpLoginUrl = React.useCallback(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const isASWebSession =
@@ -69,6 +76,10 @@ const SignIn = () => {
     const transferUrl = consumePendingMembershipTransferReturnUrl();
     if (transferUrl) {
       return transferUrl;
+    }
+    const redirectUrl = consumePostLoginRedirect();
+    if (redirectUrl) {
+      return redirectUrl;
     }
     return "/account";
   }, []);

--- a/src/pages/admin/AdminBroadcastEmail.tsx
+++ b/src/pages/admin/AdminBroadcastEmail.tsx
@@ -25,6 +25,9 @@ const AUDIENCE_OPTIONS: { value: BroadcastEmailAudience; label: string }[] = [
   { value: "opted_in", label: "Opted in to tips & offers only" },
 ];
 
+const DEFAULT_CTA_LABEL = "View perks";
+const DEFAULT_CTA_URL = "https://vpnkeen.com/perks";
+
 export default function AdminBroadcastEmail() {
   const { admin, can } = useAdminAuth();
   const { toast } = useToast();
@@ -39,8 +42,8 @@ export default function AdminBroadcastEmail() {
   const [headline, setHeadline] = useState("");
   const [body, setBody] = useState("");
   const [preheader, setPreheader] = useState("");
-  const [ctaLabel, setCtaLabel] = useState("View perks");
-  const [ctaUrl, setCtaUrl] = useState("https://vpnkeen.com/perks");
+  const [ctaLabel, setCtaLabel] = useState(DEFAULT_CTA_LABEL);
+  const [ctaUrl, setCtaUrl] = useState(DEFAULT_CTA_URL);
   const [previewing, setPreviewing] = useState(false);
   const [sending, setSending] = useState(false);
   const [exporting, setExporting] = useState(false);
@@ -53,6 +56,15 @@ export default function AdminBroadcastEmail() {
       body.trim().length > 0,
     [subject, headline, body],
   );
+
+  const resetComposeForm = useCallback(() => {
+    setSubject("");
+    setHeadline("");
+    setBody("");
+    setPreheader("");
+    setCtaLabel(DEFAULT_CTA_LABEL);
+    setCtaUrl(DEFAULT_CTA_URL);
+  }, []);
 
   const composePayload = useCallback(
     () => ({
@@ -175,6 +187,7 @@ export default function AdminBroadcastEmail() {
       return;
     }
 
+    resetComposeForm();
     toast({
       title: "Broadcast queued in Resend",
       description: `Broadcast ${result.data.broadcastId} — ${result.data.syncedContactCount.toLocaleString()} contacts synced.`,


### PR DESCRIPTION
## Summary
- Preserve the intended destination when unauthenticated users hit protected routes (e.g. broadcast email CTA to `/perks`), and return them there after OAuth or OTP sign-in.
- Clear the admin broadcast compose form after a successful send so the next broadcast starts from a blank template.

## Test plan
- [ ] Log out, open `https://vpnkeen.com/perks`, confirm redirect to `/signin?redirect=%2Fperks`
- [ ] Sign in with Google/Apple/OTP and confirm landing on `/perks` (not `/account`)
- [ ] Send a broadcast from admin, confirm success toast and compose fields reset while audience selection stays
- [ ] Confirm ASWeb (`?asweb=1`) sign-in still lands on `/account?asweb=1`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->