### PR TITLE
Poll broadcast send jobs for large audiences

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -3999,6 +3999,26 @@ export async function adminSendBroadcastPreview(
   }
 }
 
+export type BroadcastEmailJobStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed";
+
+export interface BroadcastEmailJobStatusPayload {
+  jobId: string;
+  status: BroadcastEmailJobStatus;
+  audience: string;
+  recipientCount: number;
+  syncedContactCount: number;
+  broadcastId: string | null;
+  sendImmediately: boolean;
+  errorMessage: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+}
+
 export async function adminSendBroadcastEmail(
   payload: AdminBroadcastComposePayload & {
     confirmRecipientCount: number;
@@ -4007,9 +4027,9 @@ export async function adminSendBroadcastEmail(
 ): Promise<{
   ok: boolean;
   data?: {
-    broadcastId: string;
+    jobId: string;
+    status: BroadcastEmailJobStatus;
     recipientCount: number;
-    syncedContactCount: number;
     sendImmediately: boolean;
   };
   error?: string;
@@ -4030,12 +4050,42 @@ export async function adminSendBroadcastEmail(
     }
     const record = raw as {
       data?: {
-        broadcastId: string;
+        jobId: string;
+        status: BroadcastEmailJobStatus;
         recipientCount: number;
-        syncedContactCount: number;
         sendImmediately: boolean;
       };
     };
+    return { ok: true, data: record.data };
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "Network error",
+    };
+  }
+}
+
+export async function adminFetchBroadcastEmailJob(jobId: string): Promise<{
+  ok: boolean;
+  data?: BroadcastEmailJobStatusPayload;
+  error?: string;
+}> {
+  try {
+    const response = await fetch(
+      `${BACKEND_URL}/admin/broadcast-email/jobs/${encodeURIComponent(jobId)}`,
+      {
+        method: "GET",
+        credentials: "include",
+      },
+    );
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(raw, "Failed to load broadcast job"),
+      };
+    }
+    const record = raw as { data?: BroadcastEmailJobStatusPayload };
     return { ok: true, data: record.data };
   } catch (e) {
     return {

--- a/src/pages/admin/AdminBroadcastEmail.tsx
+++ b/src/pages/admin/AdminBroadcastEmail.tsx
@@ -56,6 +56,13 @@ export default function AdminBroadcastEmail() {
   const [sendProgress, setSendProgress] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const audienceRequestIdRef = useRef(0);
+  const broadcastPollActiveRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      broadcastPollActiveRef.current = false;
+    };
+  }, []);
 
   const composeReady = useMemo(
     () =>
@@ -201,19 +208,26 @@ export default function AdminBroadcastEmail() {
     const jobId = result.data.jobId;
     const deadline = Date.now() + BROADCAST_JOB_POLL_TIMEOUT_MS;
     let completed = false;
+    broadcastPollActiveRef.current = true;
 
     while (Date.now() < deadline) {
-      await sleep(BROADCAST_JOB_POLL_INTERVAL_MS);
-      const statusResult = await adminFetchBroadcastEmailJob(jobId);
-      if (!statusResult.ok || !statusResult.data) {
-        setSending(false);
-        setSendProgress(null);
-        toast({
-          title: "Broadcast status unavailable",
-          description: statusResult.error ?? "Try again.",
-          variant: "destructive",
-        });
+      if (!broadcastPollActiveRef.current) {
         return;
+      }
+
+      await sleep(BROADCAST_JOB_POLL_INTERVAL_MS);
+      if (!broadcastPollActiveRef.current) {
+        return;
+      }
+
+      const statusResult = await adminFetchBroadcastEmailJob(jobId);
+      if (!broadcastPollActiveRef.current) {
+        return;
+      }
+
+      if (!statusResult.ok || !statusResult.data) {
+        setSendProgress("Waiting for broadcast status…");
+        continue;
       }
 
       const job = statusResult.data;
@@ -228,6 +242,7 @@ export default function AdminBroadcastEmail() {
         continue;
       }
       if (job.status === "failed") {
+        broadcastPollActiveRef.current = false;
         setSending(false);
         setSendProgress(null);
         toast({
@@ -240,6 +255,7 @@ export default function AdminBroadcastEmail() {
       }
       if (job.status === "completed") {
         completed = true;
+        broadcastPollActiveRef.current = false;
         setSending(false);
         setSendProgress(null);
         resetComposeForm();
@@ -253,13 +269,19 @@ export default function AdminBroadcastEmail() {
       }
     }
 
+    if (!broadcastPollActiveRef.current) {
+      return;
+    }
+
+    broadcastPollActiveRef.current = false;
+
     if (!completed) {
       setSending(false);
       setSendProgress(null);
       toast({
         title: "Broadcast still processing",
         description:
-          "This large send is still running in the background. Check Netlify logs or retry status in a few minutes.",
+          "This large send is still running in the background. Refresh this page and check Netlify logs if needed.",
         variant: "destructive",
       });
     }

--- a/src/pages/admin/AdminBroadcastEmail.tsx
+++ b/src/pages/admin/AdminBroadcastEmail.tsx
@@ -14,6 +14,7 @@ import { useToast } from "@/hooks/use-toast";
 import {
   adminExportBroadcastAudienceCsv,
   adminFetchBroadcastAudience,
+  adminFetchBroadcastEmailJob,
   adminSendBroadcastEmail,
   adminSendBroadcastPreview,
   type BroadcastEmailAudience,
@@ -27,6 +28,12 @@ const AUDIENCE_OPTIONS: { value: BroadcastEmailAudience; label: string }[] = [
 
 const DEFAULT_CTA_LABEL = "View perks";
 const DEFAULT_CTA_URL = "https://vpnkeen.com/perks";
+const BROADCAST_JOB_POLL_INTERVAL_MS = 2000;
+const BROADCAST_JOB_POLL_TIMEOUT_MS = 15 * 60 * 1000;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
 
 export default function AdminBroadcastEmail() {
   const { admin, can } = useAdminAuth();
@@ -46,6 +53,7 @@ export default function AdminBroadcastEmail() {
   const [ctaUrl, setCtaUrl] = useState(DEFAULT_CTA_URL);
   const [previewing, setPreviewing] = useState(false);
   const [sending, setSending] = useState(false);
+  const [sendProgress, setSendProgress] = useState<string | null>(null);
   const [exporting, setExporting] = useState(false);
   const audienceRequestIdRef = useRef(0);
 
@@ -171,14 +179,17 @@ export default function AdminBroadcastEmail() {
     if (!confirmed) return;
 
     setSending(true);
+    setSendProgress("Queueing broadcast…");
+
     const result = await adminSendBroadcastEmail({
       ...composePayload(),
       confirmRecipientCount: recipientCount,
       sendImmediately: true,
     });
-    setSending(false);
 
-    if (!result.ok || !result.data) {
+    if (!result.ok || !result.data?.jobId) {
+      setSending(false);
+      setSendProgress(null);
       toast({
         title: "Broadcast failed",
         description: result.error ?? "Try again.",
@@ -187,11 +198,71 @@ export default function AdminBroadcastEmail() {
       return;
     }
 
-    resetComposeForm();
-    toast({
-      title: "Broadcast queued in Resend",
-      description: `Broadcast ${result.data.broadcastId} — ${result.data.syncedContactCount.toLocaleString()} contacts synced.`,
-    });
+    const jobId = result.data.jobId;
+    const deadline = Date.now() + BROADCAST_JOB_POLL_TIMEOUT_MS;
+    let completed = false;
+
+    while (Date.now() < deadline) {
+      await sleep(BROADCAST_JOB_POLL_INTERVAL_MS);
+      const statusResult = await adminFetchBroadcastEmailJob(jobId);
+      if (!statusResult.ok || !statusResult.data) {
+        setSending(false);
+        setSendProgress(null);
+        toast({
+          title: "Broadcast status unavailable",
+          description: statusResult.error ?? "Try again.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const job = statusResult.data;
+      if (job.status === "pending") {
+        setSendProgress("Preparing broadcast…");
+        continue;
+      }
+      if (job.status === "processing") {
+        setSendProgress(
+          `Syncing contacts to Resend… ${job.syncedContactCount.toLocaleString()} / ${job.recipientCount.toLocaleString()}`,
+        );
+        continue;
+      }
+      if (job.status === "failed") {
+        setSending(false);
+        setSendProgress(null);
+        toast({
+          title: "Broadcast failed",
+          description:
+            job.errorMessage ?? "Check server logs for the latest sync error.",
+          variant: "destructive",
+        });
+        return;
+      }
+      if (job.status === "completed") {
+        completed = true;
+        setSending(false);
+        setSendProgress(null);
+        resetComposeForm();
+        toast({
+          title: "Broadcast queued in Resend",
+          description: job.broadcastId
+            ? `Broadcast ${job.broadcastId} — ${job.syncedContactCount.toLocaleString()} contacts synced.`
+            : `${job.syncedContactCount.toLocaleString()} contacts synced.`,
+        });
+        break;
+      }
+    }
+
+    if (!completed) {
+      setSending(false);
+      setSendProgress(null);
+      toast({
+        title: "Broadcast still processing",
+        description:
+          "This large send is still running in the background. Check Netlify logs or retry status in a few minutes.",
+        variant: "destructive",
+      });
+    }
   };
 
   if (!canBroadcast) {
@@ -360,6 +431,10 @@ export default function AdminBroadcastEmail() {
           {sending ? "Sending…" : "Send broadcast"}
         </Button>
       </div>
+
+      {sendProgress ? (
+        <p className="text-sm text-muted-foreground">{sendProgress}</p>
+      ) : null}
 
       <p className="text-xs text-muted-foreground">
         Requires `RESEND_BROADCAST_SEGMENT_ID` on the backend. Recipients are


### PR DESCRIPTION
## Summary
- Update admin broadcast send flow to queue a job and poll status until complete
- Show live sync progress (`Syncing contacts… X / Y`) for large sends
- Depends on backend async broadcast job API

## Test plan
- [ ] Small send (~13) completes with success toast
- [ ] Large send (289+) shows progress and completes without browser 504
- [ ] Failed job shows error toast with server message

## Note
This branch also includes the perks post-login redirect + form reset commits from `fix/perks-post-login-redirect`. Merge that PR first or merge this as a bundle.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->