### PR TITLE
Auto-return to macOS app after web Google sign-in and hide Apple on A…

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -8,6 +8,7 @@ import {
   clearUtmAttributionStorage,
   getUtmAttributionAuthPayload,
 } from "@/lib/utm-attribution";
+import { buildAuthDeepLink } from "@/lib/keenvpn-deep-links";
 
 export const BACKEND_URL =
   import.meta.env.VITE_BACKEND_URL || "/api";
@@ -3435,8 +3436,8 @@ const APP_TOKEN_KEY = "token";
 
 export function storeSessionToken(sessionToken: string): void {
   localStorage.setItem(SESSION_TOKEN_KEY, sessionToken);
-  // Also store for app deeplink
-  localStorage.setItem(APP_TOKEN_KEY, `vpnkeen://auth?token=${sessionToken}`);
+  // Also store for app deeplink (token is URL-encoded for safe query parsing)
+  localStorage.setItem(APP_TOKEN_KEY, buildAuthDeepLink(sessionToken));
 }
 
 export function getSessionToken(): string | null {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,7 +27,10 @@ import {
   consumePendingMembershipTransfer,
   consumePendingMembershipTransferReturnUrl,
 } from "@/auth/membership-transfer-flow";
-import { clearStripeCheckoutReturn } from "@/lib/keenvpn-deep-links";
+import {
+  clearStripeCheckoutReturn,
+  maybeAutoReturnToKeenVpnAppAfterAuth,
+} from "@/lib/keenvpn-deep-links";
 
 // ============================================================================
 // Context Types
@@ -292,8 +295,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
               // Check if this is from ASWebAuthenticationSession (macOS desktop app)
               if (isASWebSession()) {
+                maybeAutoReturnToKeenVpnAppAfterAuth(backendResponse.sessionToken);
                 if (window.location.pathname !== '/account') {
-                  console.log('🔐 ASWebAuthenticationSession (redirect) - redirecting to /account for manual deeplink');
+                  console.log('🔐 ASWebAuthenticationSession (redirect) - redirecting to /account for app callback fallback');
                   window.location.href = '/account?asweb=1';
                 }
                 return;
@@ -391,7 +395,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
             // Check if this is from ASWebAuthenticationSession (macOS desktop app)
             if (isASWebSession() && window.location.pathname === '/signin') {
-              console.log('🔐 ASWebSession detected - user already logged in on signin, redirecting to account');
+              console.log('🔐 ASWebSession detected - user already logged in on signin, returning to app');
+              maybeAutoReturnToKeenVpnAppAfterAuth(sessionToken);
               window.location.href = '/account?asweb=1';
               setLoading(false);
               return;
@@ -462,6 +467,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
                 refreshLinkedProviders(backendResponse.sessionToken);
 
                 if (window.location.pathname === '/signin') {
+                  if (isASWebSession()) {
+                    maybeAutoReturnToKeenVpnAppAfterAuth(backendResponse.sessionToken);
+                  }
                   window.location.href = postLoginUrl();
                   return;
                 }
@@ -660,6 +668,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setTrial(response.trial ?? null);
           void fetchSubscriptionFromBackend(token);
           if (window.location.pathname === '/signin') {
+            if (isASWebSession()) {
+              maybeAutoReturnToKeenVpnAppAfterAuth(token);
+            }
             window.location.href = postLoginUrl();
             setIsAuthenticating(false);
             return { success: true };
@@ -710,12 +721,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setIsAuthenticating(false);
 
         dismissToast();
-        toast({
-          title: "Welcome back!",
-          description: "Redirecting to your account...",
-        });
 
-        // After any successful login, always land on account.
+        if (isASWebSession()) {
+          maybeAutoReturnToKeenVpnAppAfterAuth(backendResponse.sessionToken);
+          toast({
+            title: "Welcome back!",
+            description: "Returning to KeenVPN...",
+          });
+        } else {
+          toast({
+            title: "Welcome back!",
+            description: "Redirecting to your account...",
+          });
+        }
+
+        // After any successful login, always land on account (fallback if app handoff fails).
         if (window.location.pathname !== '/account') {
           window.location.href = postLoginUrl();
         }
@@ -874,7 +894,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   return (
     <AuthContext.Provider value={value}>
       {children}
-
     </AuthContext.Provider>
   );
 };

--- a/src/lib/keenvpn-deep-links.ts
+++ b/src/lib/keenvpn-deep-links.ts
@@ -18,6 +18,8 @@ export const AUTH_DEEP_LINK_PREFIX = `${KEENVPN_URL_SCHEME}://auth`;
 
 export const RETURN_TO_APP_LABEL = "Return to KeenVPN App";
 
+const ASWEB_AUTH_AUTO_OPEN_DONE_KEY = "keenvpn_asweb_auth_auto_open_done";
+
 const STRIPE_CHECKOUT_RETURN_KEY = "keenvpn_stripe_checkout_return";
 const STRIPE_AUTO_OPEN_DONE_KEY = "keenvpn_stripe_auto_open_done";
 const STRIPE_POST_CHECKOUT_UI_DISMISSED_KEY = "keenvpn_stripe_post_checkout_ui_dismissed";
@@ -136,12 +138,93 @@ export function openKeenVpnNativeApp(deepLink: string = PAYMENT_SUCCESS_DEEP_LIN
   window.setTimeout(() => anchor.remove(), 100);
 }
 
+/** Build auth callback URL with a URL-encoded session token. */
+export function buildAuthDeepLink(sessionToken: string): string {
+  return `${AUTH_DEEP_LINK_PREFIX}?token=${encodeURIComponent(sessionToken)}`;
+}
+
+/**
+ * Prefer `vpnkeen://auth?token=…` when the web session has a backend token so the
+ * native app can sign in. Falls back to purpose-specific links when logged out.
+ */
+export function resolveNativeAppHandoffDeepLink(
+  sessionToken: string | null | undefined,
+  fallback: string = OPEN_APP_DEEP_LINK,
+): string {
+  const token = sessionToken?.trim();
+  return token ? buildAuthDeepLink(token) : fallback;
+}
+
 /**
  * Return to the native app after Stripe checkout. Does not hide post-checkout UI;
  * callers should dismiss explicitly (e.g. "Continue on web") so users can retry the deep link.
  */
 export function returnToKeenVpnAppAfterPayment(
-  deepLink: string = PAYMENT_SUCCESS_DEEP_LINK,
+  sessionToken?: string | null,
 ): void {
-  openKeenVpnNativeApp(deepLink);
+  openKeenVpnNativeApp(
+    resolveNativeAppHandoffDeepLink(sessionToken, PAYMENT_SUCCESS_DEEP_LINK),
+  );
+}
+
+/** True when the page was opened from macOS ASWebAuthenticationSession (Google login). */
+export function isAsWebAuthSession(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    const urlParams = new URLSearchParams(window.location.search);
+    return (
+      urlParams.get("asweb") === "1" ||
+      sessionStorage.getItem("asweb_session") === "1"
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Prevent duplicate programmatic auth handoffs for the same session token. */
+export function shouldAutoOpenAppAfterAsWebAuth(sessionToken: string): boolean {
+  if (!sessionToken) {
+    return false;
+  }
+  try {
+    return sessionStorage.getItem(ASWEB_AUTH_AUTO_OPEN_DONE_KEY) !== sessionToken;
+  } catch {
+    return false;
+  }
+}
+
+export function markAsWebAuthAutoOpenDone(sessionToken: string): void {
+  if (!sessionToken) {
+    return;
+  }
+  try {
+    sessionStorage.setItem(ASWEB_AUTH_AUTO_OPEN_DONE_KEY, sessionToken);
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Hand off session token to the native app after ASWeb Google login. */
+export function returnToKeenVpnAppAfterAuth(sessionToken: string): void {
+  openKeenVpnNativeApp(buildAuthDeepLink(sessionToken));
+}
+
+/**
+ * Auto-return to KeenVPN after web OAuth when opened from ASWebAuthenticationSession.
+ * Returns true when a handoff was attempted.
+ */
+export function maybeAutoReturnToKeenVpnAppAfterAuth(
+  sessionToken: string,
+): boolean {
+  if (!sessionToken || !isAsWebAuthSession()) {
+    return false;
+  }
+  if (!shouldAutoOpenAppAfterAsWebAuth(sessionToken)) {
+    return false;
+  }
+  markAsWebAuthAutoOpenDone(sessionToken);
+  returnToKeenVpnAppAfterAuth(sessionToken);
+  return true;
 }

--- a/src/lib/open-app-or-store.ts
+++ b/src/lib/open-app-or-store.ts
@@ -1,8 +1,10 @@
+import { getSessionToken } from "@/auth";
 import type { SubscriptionData } from "@/auth/types";
 import { detectDevice, isAppDeepLinkSupported } from "@/lib/device-detection";
 import {
   openKeenVpnNativeApp,
   OPEN_APP_DEEP_LINK,
+  resolveNativeAppHandoffDeepLink,
 } from "@/lib/keenvpn-deep-links";
 import { hasManageableSubscription } from "@/lib/subscription-cta";
 
@@ -30,10 +32,18 @@ export function shouldOpenNativeAppFirst(
 /** If the tab stays visible after a deep link, assume the app is not installed. */
 const APP_OPEN_FALLBACK_MS = 5000;
 
+function resolveOpenAppDeepLink(sessionToken?: string | null): string {
+  return resolveNativeAppHandoffDeepLink(
+    sessionToken ?? getSessionToken(),
+    OPEN_APP_DEEP_LINK,
+  );
+}
+
 function openKeenVpnNativeAppWithAppStoreFallback(
   appStoreUrl: string,
-  deepLink: string = OPEN_APP_DEEP_LINK,
+  deepLink?: string,
 ): void {
+  const link = deepLink ?? resolveOpenAppDeepLink();
   let didLeavePage = false;
 
   const markLeft = () => {
@@ -54,7 +64,7 @@ function openKeenVpnNativeAppWithAppStoreFallback(
   document.addEventListener("visibilitychange", onVisibilityChange);
   window.addEventListener("pagehide", markLeft);
 
-  openKeenVpnNativeApp(deepLink);
+  openKeenVpnNativeApp(link);
 
   window.setTimeout(() => {
     cleanup();
@@ -68,10 +78,19 @@ export function openAppOrAppStore(
   subscription: SubscriptionData | null | undefined,
   appStoreUrl: string,
 ): void {
+  const deepLink = resolveOpenAppDeepLink();
+
   if (shouldOpenNativeAppFirst(subscription)) {
-    openKeenVpnNativeAppWithAppStoreFallback(appStoreUrl);
+    openKeenVpnNativeAppWithAppStoreFallback(appStoreUrl, deepLink);
     return;
   }
+
+  // Logged-in on iOS/macOS: hand off session even when subscription is web-only / trial.
+  if (getSessionToken() && isAppDeepLinkSupported()) {
+    openKeenVpnNativeAppWithAppStoreFallback(appStoreUrl, deepLink);
+    return;
+  }
+
   window.open(resolveAppStoreUrl(appStoreUrl), "_blank", "noopener,noreferrer");
 }
 

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -59,7 +59,11 @@ import Footer from "@/components/Footer";
 import { LinkedAccounts } from "@/components/LinkedAccounts";
 import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
 import { SubscriptionCancellationControls } from "@/components/SubscriptionCancellationControls";
-import { isAppDeepLinkSupported, getUnsupportedDeviceName } from "@/lib/device-detection";
+import {
+  detectDevice,
+  isAppDeepLinkSupported,
+  getUnsupportedDeviceName,
+} from "@/lib/device-detection";
 import { useAppStoreUrl } from "@/hooks/use-app-store-url";
 import {
   getAppDownloadButtonLabel,
@@ -83,11 +87,13 @@ import {
 import {
   PAYMENT_SUCCESS_DEEP_LINK,
   RETURN_TO_APP_LABEL,
+  buildAuthDeepLink,
   clearStripeCheckoutReturn,
   dismissStripePostCheckoutUi,
   markStripeAutoOpenDone,
   isStripeCheckoutReturn,
   markStripeCheckoutReturn,
+  maybeAutoReturnToKeenVpnAppAfterAuth,
   returnToKeenVpnAppAfterPayment,
   shouldAutoOpenAppAfterStripeCheckout,
   shouldShowStripePostCheckoutUi,
@@ -132,6 +138,7 @@ const Account = () => {
   );
 
   const isDeepLinkSupported = useMemo(() => isAppDeepLinkSupported(), []);
+  const isMacOS = useMemo(() => detectDevice() === "macos", []);
   const unsupportedDeviceName = useMemo(() => getUnsupportedDeviceName(), []);
 
   // ASWebAuthenticationSession detection
@@ -145,6 +152,9 @@ const Account = () => {
     }
     return detected;
   }, []);
+  const macSessionToken = hasSessionToken ? getSessionToken() : null;
+  const showOpenMacAppButton =
+    isMacOS && Boolean(macSessionToken) && !isASWeb;
   const hasStripeSessionId = useMemo(() => {
     const urlParams = new URLSearchParams(location.search);
     return Boolean(urlParams.get("session_id"));
@@ -219,7 +229,7 @@ const Account = () => {
     // Only mark auto-open done — keep banner/buttons if the deep link fails (app not installed).
     const timer = window.setTimeout(() => {
       markStripeAutoOpenDone();
-      returnToKeenVpnAppAfterPayment();
+      returnToKeenVpnAppAfterPayment(getSessionToken());
     }, 700);
 
     return () => window.clearTimeout(timer);
@@ -246,6 +256,32 @@ const Account = () => {
     }, 200);
     return () => clearInterval(id);
   }, [isASWeb, sessionToken]);
+
+  // Auto-return to the macOS app after ASWeb Google login (fallback if AuthContext handoff missed).
+  useEffect(() => {
+    if (
+      !isASWeb ||
+      !sessionToken ||
+      !isDeepLinkSupported ||
+      showPostCheckoutUi ||
+      hasStripeSessionId ||
+      isStripeCheckoutReturn()
+    ) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      maybeAutoReturnToKeenVpnAppAfterAuth(sessionToken);
+    }, 400);
+
+    return () => window.clearTimeout(timer);
+  }, [
+    isASWeb,
+    sessionToken,
+    isDeepLinkSupported,
+    showPostCheckoutUi,
+    hasStripeSessionId,
+  ]);
 
   // On first account view, ensure subscription is hydrated before rendering
   // "No active subscription". This avoids a false empty state that required reload.
@@ -701,7 +737,7 @@ const Account = () => {
                         onClick={(event) => {
                           event.preventDefault();
                           markStripeAutoOpenDone();
-                          returnToKeenVpnAppAfterPayment();
+                          returnToKeenVpnAppAfterPayment(getSessionToken());
                         }}
                       >
                         <Smartphone className="mr-2 h-5 w-5" />
@@ -760,7 +796,7 @@ const Account = () => {
                         className="bg-gradient-primary text-primary-foreground hover:opacity-90 shadow-glow"
                         size="lg"
                       >
-                        <a href={`vpnkeen://auth?token=${sessionToken}`}>
+                        <a href={buildAuthDeepLink(sessionToken)}>
                           Return to KeenVPN App
                         </a>
                       </Button>
@@ -949,7 +985,7 @@ const Account = () => {
                             onClick={(event) => {
                               event.preventDefault();
                               markStripeAutoOpenDone();
-                              returnToKeenVpnAppAfterPayment();
+                              returnToKeenVpnAppAfterPayment(getSessionToken());
                             }}
                           >
                             <Smartphone className="mr-2 h-5 w-5" />
@@ -977,6 +1013,14 @@ const Account = () => {
                         <History className="h-4 w-4 mr-2" />
                         View Billing History
                       </Button>
+
+                      {showOpenMacAppButton && macSessionToken ? (
+                        <Button asChild variant="outline" className="w-full">
+                          <a href={buildAuthDeepLink(macSessionToken)}>
+                            Open KeenVPN App
+                          </a>
+                        </Button>
+                      ) : null}
 
                       <Button
                         onClick={handleRefreshSubscription}
@@ -1039,6 +1083,13 @@ const Account = () => {
                       <History className="h-4 w-4 mr-2" />
                       Manage Subscriptions
                     </Button>
+                    {showOpenMacAppButton && macSessionToken ? (
+                      <Button asChild variant="outline" className="w-full">
+                        <a href={buildAuthDeepLink(macSessionToken)}>
+                          Open KeenVPN App
+                        </a>
+                      </Button>
+                    ) : null}
                     <Button
                       onClick={() => navigate("/subscribe")}
                       className="w-full bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg"

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -49,6 +49,22 @@ const SignIn = () => {
   const [otpLoading, setOtpLoading] = React.useState(false);
 
   const emailForOtp = otpEmail.trim().toLowerCase();
+
+  const isASWebSession = React.useMemo(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    return (
+      urlParams.get("asweb") === "1" ||
+      sessionStorage.getItem("asweb_session") === "1"
+    );
+  }, []);
+
+  React.useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get("asweb") === "1") {
+      sessionStorage.setItem("asweb_session", "1");
+    }
+  }, []);
+
   const postOtpLoginUrl = React.useCallback(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const isASWebSession =
@@ -200,9 +216,13 @@ const SignIn = () => {
 
           <Card className="border-accent/50 shadow-glow">
             <CardHeader className="text-center">
-              <CardTitle className="text-2xl">Continue with</CardTitle>
+              <CardTitle className="text-2xl">
+                {isASWebSession ? "Sign in with Google" : "Continue with"}
+              </CardTitle>
               <CardDescription>
-                Choose your preferred sign-in method
+                {isASWebSession
+                  ? "Use your Google account to continue in the KeenVPN app"
+                  : "Choose your preferred sign-in method"}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -228,25 +248,27 @@ const SignIn = () => {
                 )}
               </Button>
 
-              <Button
-                onClick={handleAppleSignIn}
-                disabled={isLoading}
-                className="w-full bg-black text-white hover:bg-gray-800"
-                size="lg"
-              >
-                {isAppleDebouncing ||
-                (providerLoading && !isGoogleDebouncing) ? (
-                  <>
-                    <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-                    {isAppleDebouncing ? "Please wait..." : "Authenticating..."}
-                  </>
-                ) : (
-                  <>
-                    <Apple className="mr-2 h-5 w-5" />
-                    Continue with Apple
-                  </>
-                )}
-              </Button>
+              {!isASWebSession ? (
+                <Button
+                  onClick={handleAppleSignIn}
+                  disabled={isLoading}
+                  className="w-full bg-black text-white hover:bg-gray-800"
+                  size="lg"
+                >
+                  {isAppleDebouncing ||
+                  (providerLoading && !isGoogleDebouncing) ? (
+                    <>
+                      <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                      {isAppleDebouncing ? "Please wait..." : "Authenticating..."}
+                    </>
+                  ) : (
+                    <>
+                      <Apple className="mr-2 h-5 w-5" />
+                      Continue with Apple
+                    </>
+                  )}
+                </Button>
+              ) : null}
 
               <div className="relative py-2">
                 <div className="absolute inset-0 flex items-center">


### PR DESCRIPTION
…SWeb.

Wire maybeAutoReturnToKeenVpnAppAfterAuth through AuthContext, add deep-link helpers, and update SignIn/Account for the ?asweb=1 desktop login flow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->