### PR TITLE
Gate native app deep links to ASWeb and use App Store download CTAs.

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,9 +11,10 @@ import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { useAppStoreUrl } from "@/hooks/use-app-store-url";
 import {
-  getAppDownloadButtonLabel,
-  openAppOrAppStore,
+  getAppStoreInstallButtonLabel,
+  resolveAppStoreUrl,
 } from "@/lib/open-app-or-store";
+import { openKeenVpnAppStore } from "@/lib/keenvpn-deep-links";
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -21,8 +22,9 @@ const Header = () => {
   const navigate = useNavigate();
   const { user, subscription, logout } = useAuth();
   const appStoreUrl = useAppStoreUrl();
-  const downloadAppLabel = getAppDownloadButtonLabel(subscription);
-  const handleDownloadApp = () => openAppOrAppStore(subscription, appStoreUrl);
+  const downloadAppLabel = getAppStoreInstallButtonLabel();
+  const handleDownloadApp = () =>
+    openKeenVpnAppStore(resolveAppStoreUrl(appStoreUrl));
 
   const isActive = (path: string) => location.pathname === path;
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -10,18 +10,17 @@ import {
   UserRound,
   Zap,
 } from "lucide-react";
-import { useAuth } from "@/contexts/AuthContext";
 import { useAppStoreUrl } from "@/hooks/use-app-store-url";
 import {
-  getAppDownloadButtonLabel,
-  openAppOrAppStore,
+  getAppStoreInstallButtonLabel,
+  resolveAppStoreUrl,
 } from "@/lib/open-app-or-store";
+import { openKeenVpnAppStore } from "@/lib/keenvpn-deep-links";
 import { Link } from "react-router-dom";
 
 const Hero = () => {
-  const { subscription } = useAuth();
   const appStoreUrl = useAppStoreUrl();
-  const downloadAppLabel = getAppDownloadButtonLabel(subscription);
+  const downloadAppLabel = getAppStoreInstallButtonLabel();
 
   return (
     <section className="relative bg-gradient-hero overflow-hidden pt-28 pb-14 md:pt-32 md:pb-20">
@@ -56,7 +55,9 @@ const Hero = () => {
             <Button
               size="lg"
               className="bg-primary text-primary-foreground hover:bg-primary/90 shadow-glow text-lg px-8 py-6 font-semibold transition-all hover:scale-105"
-              onClick={() => openAppOrAppStore(subscription, appStoreUrl)}
+              onClick={() =>
+                openKeenVpnAppStore(resolveAppStoreUrl(appStoreUrl))
+              }
             >
               <Download className="h-5 w-5" />
               {downloadAppLabel}

--- a/src/constants/app-store-urls.ts
+++ b/src/constants/app-store-urls.ts
@@ -1,9 +1,33 @@
-// App Store URLs - Update these with your actual app store links
-// Format: Replace the placeholder URLs with your actual app store links
+import type { DeviceType } from "@/lib/device-detection";
+import { detectDevice } from "@/lib/device-detection";
 
+// App Store URLs - Update these with your actual app store links
 export const APP_STORE_URLS = {
   ios: "https://apps.apple.com/us/app/keenvpn-secure-vpn/id6753761859",
   macos: "https://apps.apple.com/us/app/keenvpn-secure-vpn/id6751677565",
   android: "https://vpnkeen.com", // TODO: Add Android app store link
   fallback: "https://vpnkeen.com",
 } as const;
+
+const APPLE_APP_STORE_HOST = /apps\.apple\.com/i;
+
+/** Opens the native App Store app on Apple platforms instead of the web storefront. */
+export function toNativeAppStoreSchemeUrl(
+  url: string,
+  device: DeviceType = detectDevice(),
+): string {
+  if (!/^https:\/\/apps\.apple\.com\//i.test(url)) {
+    return url;
+  }
+  if (device === "macos") {
+    return url.replace(/^https:\/\//i, "macappstore://");
+  }
+  if (device === "ios") {
+    return url.replace(/^https:\/\//i, "itms-apps://");
+  }
+  return url;
+}
+
+export function isAppleAppStoreUrl(url: string): boolean {
+  return APPLE_APP_STORE_HOST.test(url);
+}

--- a/src/lib/keenvpn-deep-links.ts
+++ b/src/lib/keenvpn-deep-links.ts
@@ -1,3 +1,10 @@
+import {
+  APP_STORE_URLS,
+  isAppleAppStoreUrl,
+  toNativeAppStoreSchemeUrl,
+} from "@/constants/app-store-urls";
+import { detectDevice } from "@/lib/device-detection";
+
 /**
  * KeenVPN native app deep links (iOS + macOS only).
  * Registered schemes: vpnkeen, keenvpn (iOS). Prefer vpnkeen for web → app handoff.
@@ -112,15 +119,49 @@ export function clearStripeCheckoutReturn(): void {
   }
 }
 
+function resolveAppStoreDownloadUrl(downloadPageUrl?: string): string {
+  const device = detectDevice();
+  if (downloadPageUrl && isAppleAppStoreUrl(downloadPageUrl)) {
+    return downloadPageUrl;
+  }
+  if (device === "ios") return APP_STORE_URLS.ios;
+  if (device === "macos") return APP_STORE_URLS.macos;
+  if (downloadPageUrl && /^https?:\/\//i.test(downloadPageUrl)) {
+    return downloadPageUrl;
+  }
+  return APP_STORE_URLS.fallback;
+}
+
+/** Opens the platform App Store page — never uses vpnkeen:// custom schemes. */
+export function openKeenVpnAppStore(downloadPageUrl?: string): void {
+  const webUrl = resolveAppStoreDownloadUrl(downloadPageUrl);
+  const url = toNativeAppStoreSchemeUrl(webUrl);
+
+  // Native store schemes open the App Store app; https links stay in the browser.
+  if (/^(macappstore|itms-apps):/i.test(url)) {
+    window.location.assign(url);
+    return;
+  }
+
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+/** @deprecated Use {@link openKeenVpnAppStore} */
+export const openKeenVpnDownloadPage = openKeenVpnAppStore;
+
 /**
  * Programmatic handoff to the native KeenVPN app via custom URL scheme.
- *
- * Uses both a hidden iframe and a synthetic anchor click: Safari / ASWebAuthenticationSession
- * often ignores anchor-only navigation for custom schemes, while the iframe can still reach
- * the OS handler. Anchor remains the primary path in normal Safari tabs. Iframe creation is
- * wrapped in try/catch for environments that block iframes.
+ * Only allowed when {@link isNativeAppWebSession} — otherwise opens the App Store.
  */
-export function openKeenVpnNativeApp(deepLink: string = PAYMENT_SUCCESS_DEEP_LINK): void {
+export function openKeenVpnNativeApp(
+  deepLink: string = PAYMENT_SUCCESS_DEEP_LINK,
+  downloadPageUrl?: string,
+): void {
+  if (!isNativeAppWebSession()) {
+    openKeenVpnAppStore(downloadPageUrl);
+    return;
+  }
+
   try {
     const iframe = document.createElement("iframe");
     iframe.style.display = "none";
@@ -144,8 +185,8 @@ export function buildAuthDeepLink(sessionToken: string): string {
 }
 
 /**
- * Prefer `vpnkeen://auth?token=…` when the web session has a backend token so the
- * native app can sign in. Falls back to purpose-specific links when logged out.
+ * Deep link for return-to-app handoffs. Only call when {@link isNativeAppWebSession}.
+ * Attaches session token when available so the native app can sign in.
  */
 export function resolveNativeAppHandoffDeepLink(
   sessionToken: string | null | undefined,
@@ -161,14 +202,19 @@ export function resolveNativeAppHandoffDeepLink(
  */
 export function returnToKeenVpnAppAfterPayment(
   sessionToken?: string | null,
+  downloadPageUrl?: string,
 ): void {
   openKeenVpnNativeApp(
     resolveNativeAppHandoffDeepLink(sessionToken, PAYMENT_SUCCESS_DEEP_LINK),
+    downloadPageUrl,
   );
 }
 
-/** True when the page was opened from macOS ASWebAuthenticationSession (Google login). */
-export function isAsWebAuthSession(): boolean {
+/**
+ * True when this browser tab was opened from the native KeenVPN app
+ * (ASWebAuthenticationSession / in-app browser with `?asweb=1`).
+ */
+export function isNativeAppWebSession(): boolean {
   if (typeof window === "undefined") {
     return false;
   }
@@ -182,6 +228,9 @@ export function isAsWebAuthSession(): boolean {
     return false;
   }
 }
+
+/** @deprecated Use {@link isNativeAppWebSession} */
+export const isAsWebAuthSession = isNativeAppWebSession;
 
 /** Prevent duplicate programmatic auth handoffs for the same session token. */
 export function shouldAutoOpenAppAfterAsWebAuth(sessionToken: string): boolean {
@@ -207,8 +256,11 @@ export function markAsWebAuthAutoOpenDone(sessionToken: string): void {
 }
 
 /** Hand off session token to the native app after ASWeb Google login. */
-export function returnToKeenVpnAppAfterAuth(sessionToken: string): void {
-  openKeenVpnNativeApp(buildAuthDeepLink(sessionToken));
+export function returnToKeenVpnAppAfterAuth(
+  sessionToken: string,
+  downloadPageUrl?: string,
+): void {
+  openKeenVpnNativeApp(buildAuthDeepLink(sessionToken), downloadPageUrl);
 }
 
 /**
@@ -218,7 +270,7 @@ export function returnToKeenVpnAppAfterAuth(sessionToken: string): void {
 export function maybeAutoReturnToKeenVpnAppAfterAuth(
   sessionToken: string,
 ): boolean {
-  if (!sessionToken || !isAsWebAuthSession()) {
+  if (!sessionToken || !isNativeAppWebSession()) {
     return false;
   }
   if (!shouldAutoOpenAppAfterAsWebAuth(sessionToken)) {

--- a/src/lib/open-app-or-store.ts
+++ b/src/lib/open-app-or-store.ts
@@ -2,6 +2,8 @@ import { getSessionToken } from "@/auth";
 import type { SubscriptionData } from "@/auth/types";
 import { detectDevice, isAppDeepLinkSupported } from "@/lib/device-detection";
 import {
+  isNativeAppWebSession,
+  openKeenVpnAppStore,
   openKeenVpnNativeApp,
   OPEN_APP_DEEP_LINK,
   resolveNativeAppHandoffDeepLink,
@@ -20,12 +22,14 @@ export function getAppStoreInstallButtonLabel(): string {
   return "Download KeenVPN App";
 }
 
-/** Paying subscribers on iOS/macOS: open the native app instead of the App Store. */
+/** True only when opened from the native app and a deep link is supported on this device. */
 export function shouldOpenNativeAppFirst(
   subscription: SubscriptionData | null | undefined,
 ): boolean {
   return (
-    hasManageableSubscription(subscription) && isAppDeepLinkSupported()
+    isNativeAppWebSession() &&
+    hasManageableSubscription(subscription) &&
+    isAppDeepLinkSupported()
   );
 }
 
@@ -44,6 +48,7 @@ function openKeenVpnNativeAppWithAppStoreFallback(
   deepLink?: string,
 ): void {
   const link = deepLink ?? resolveOpenAppDeepLink();
+  const resolvedStoreUrl = resolveAppStoreUrl(appStoreUrl);
   let didLeavePage = false;
 
   const markLeft = () => {
@@ -64,34 +69,34 @@ function openKeenVpnNativeAppWithAppStoreFallback(
   document.addEventListener("visibilitychange", onVisibilityChange);
   window.addEventListener("pagehide", markLeft);
 
-  openKeenVpnNativeApp(link);
+  openKeenVpnNativeApp(link, resolvedStoreUrl);
 
   window.setTimeout(() => {
     cleanup();
     if (!didLeavePage) {
-      window.open(resolveAppStoreUrl(appStoreUrl), "_blank", "noopener,noreferrer");
+      openKeenVpnAppStore(resolvedStoreUrl);
     }
   }, APP_OPEN_FALLBACK_MS);
 }
 
+/**
+ * Opens the native app when this page was launched from the app; otherwise App Store / download.
+ */
 export function openAppOrAppStore(
   subscription: SubscriptionData | null | undefined,
   appStoreUrl: string,
 ): void {
-  const deepLink = resolveOpenAppDeepLink();
+  const storeUrl = resolveAppStoreUrl(appStoreUrl);
 
-  if (shouldOpenNativeAppFirst(subscription)) {
-    openKeenVpnNativeAppWithAppStoreFallback(appStoreUrl, deepLink);
+  if (!isNativeAppWebSession()) {
+    openKeenVpnAppStore(storeUrl);
     return;
   }
 
-  // Logged-in on iOS/macOS: hand off session even when subscription is web-only / trial.
-  if (getSessionToken() && isAppDeepLinkSupported()) {
-    openKeenVpnNativeAppWithAppStoreFallback(appStoreUrl, deepLink);
-    return;
-  }
-
-  window.open(resolveAppStoreUrl(appStoreUrl), "_blank", "noopener,noreferrer");
+  openKeenVpnNativeAppWithAppStoreFallback(
+    appStoreUrl,
+    resolveOpenAppDeepLink(),
+  );
 }
 
 export function getAppDownloadButtonLabel(

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -67,9 +67,10 @@ import {
 } from "@/lib/device-detection";
 import { useAppStoreUrl } from "@/hooks/use-app-store-url";
 import {
-  getAppDownloadButtonLabel,
-  openAppOrAppStore,
+  getAppStoreInstallButtonLabel,
+  resolveAppStoreUrl,
 } from "@/lib/open-app-or-store";
+import { openKeenVpnAppStore } from "@/lib/keenvpn-deep-links";
 import { useSubscriptionBillingActions } from "@/hooks/use-subscription-billing-actions";
 import { useAnnualUpgrade } from "@/hooks/use-annual-upgrade";
 import {
@@ -82,19 +83,17 @@ import {
   canUpgradeStripeToAnnual,
   getSubscriptionCtaLabel,
   hasManageableSubscription,
-  isStripeSubscription,
   shouldShowAnnualUpgradeOffer,
 } from "@/lib/subscription-cta";
 import {
-  PAYMENT_SUCCESS_DEEP_LINK,
   RETURN_TO_APP_LABEL,
-  buildAuthDeepLink,
   clearStripeCheckoutReturn,
   dismissStripePostCheckoutUi,
   markStripeAutoOpenDone,
   isStripeCheckoutReturn,
   markStripeCheckoutReturn,
   maybeAutoReturnToKeenVpnAppAfterAuth,
+  returnToKeenVpnAppAfterAuth,
   returnToKeenVpnAppAfterPayment,
   shouldAutoOpenAppAfterStripeCheckout,
   shouldShowStripePostCheckoutUi,
@@ -153,9 +152,6 @@ const Account = () => {
     }
     return detected;
   }, []);
-  const macSessionToken = hasSessionToken ? getSessionToken() : null;
-  const showOpenMacAppButton =
-    isMacOS && Boolean(macSessionToken) && !isASWeb;
   const hasStripeSessionId = useMemo(() => {
     const urlParams = new URLSearchParams(location.search);
     return Boolean(urlParams.get("session_id"));
@@ -209,8 +205,7 @@ const Account = () => {
   const showPaymentCompleteBanner =
     Boolean(user) && hasSessionToken && showPostCheckoutUi;
 
-  const showReturnToAppCta =
-    showPaymentCompleteBanner && isDeepLinkSupported;
+  const showReturnToAppCta = showPaymentCompleteBanner && isASWeb;
 
   // Intentionally not calling clearStripeCheckoutReturn here — dismiss hides UI via
   // STRIPE_POST_CHECKOUT_UI_DISMISSED_KEY while preserving return/auto-open markers.
@@ -220,25 +215,24 @@ const Account = () => {
   };
 
   useEffect(() => {
-    if (!showPostCheckoutUi || !isDeepLinkSupported || isASWeb) {
+    if (!showPostCheckoutUi || !isASWeb) {
       return;
     }
     if (!initialSubscriptionChecked || !shouldAutoOpenAppAfterStripeCheckout()) {
       return;
     }
 
-    // Only mark auto-open done — keep banner/buttons if the deep link fails (app not installed).
     const timer = window.setTimeout(() => {
       markStripeAutoOpenDone();
-      returnToKeenVpnAppAfterPayment(getSessionToken());
+      returnToKeenVpnAppAfterPayment(getSessionToken(), appStoreUrl);
     }, 700);
 
     return () => window.clearTimeout(timer);
   }, [
     showPostCheckoutUi,
-    isDeepLinkSupported,
     isASWeb,
     initialSubscriptionChecked,
+    appStoreUrl,
   ]);
 
   // The session token may not be in localStorage yet when Account first mounts
@@ -392,12 +386,6 @@ const Account = () => {
     showStripeUpgradeToAnnual && !showAnnualUpgradeBanner;
   const showAppleIapUpgradeInCard =
     showAppleIapUpgradeToAnnual && !showAnnualUpgradeBanner;
-  // Stripe + active/trialing/past_due (not only status==="active") — download + cancel CTAs.
-  const isStripeManageable =
-    isStripeSubscription(subscription) &&
-    hasManageableSubscription(subscription);
-  const downloadAppButtonLabel = getAppDownloadButtonLabel(subscription);
-
   const handleDeleteAccount = async () => {
     if (!user) return;
     const token = getSessionToken();
@@ -721,34 +709,30 @@ const Account = () => {
                   </h3>
                   <p className="mt-1 text-sm text-muted-foreground">
                     Thanks for trying KeenVPN. Your subscription is active.{" "}
-                    {isDeepLinkSupported
+                    {isASWeb
                       ? "Return to the app and connect to KeenVPN."
-                      : `Install KeenVPN on your ${unsupportedDeviceName} to connect.`}
+                      : isDeepLinkSupported
+                        ? "Download KeenVPN to connect on this device."
+                        : `Install KeenVPN on your ${unsupportedDeviceName} to connect.`}
                   </p>
                 </div>
-                {isDeepLinkSupported ? (
+                {isASWeb ? (
                   <>
                     <Button
-                      asChild
+                      type="button"
                       className="w-full max-w-sm bg-gradient-primary text-primary-foreground shadow-glow hover:opacity-90"
                       size="lg"
+                      onClick={() => {
+                        markStripeAutoOpenDone();
+                        returnToKeenVpnAppAfterPayment(getSessionToken(), appStoreUrl);
+                      }}
                     >
-                      <a
-                        href={PAYMENT_SUCCESS_DEEP_LINK}
-                        onClick={(event) => {
-                          event.preventDefault();
-                          markStripeAutoOpenDone();
-                          returnToKeenVpnAppAfterPayment(getSessionToken());
-                        }}
-                      >
-                        <Smartphone className="mr-2 h-5 w-5" />
-                        {RETURN_TO_APP_LABEL}
-                      </a>
+                      <Smartphone className="mr-2 h-5 w-5" />
+                      {RETURN_TO_APP_LABEL}
                     </Button>
                     <p className="text-center text-xs text-muted-foreground">
-                      {isASWeb
-                        ? "Tap the button above to return to KeenVPN. This page stays open until you continue on web."
-                        : "If the app did not open automatically, tap the button above."}
+                      Tap the button above to return to KeenVPN. This page stays
+                      open until you continue on web.
                     </p>
                     <Button
                       type="button"
@@ -765,9 +749,11 @@ const Account = () => {
                     type="button"
                     className="w-full max-w-sm bg-gradient-primary text-primary-foreground shadow-glow hover:opacity-90"
                     size="lg"
-                    onClick={() => openAppOrAppStore(subscription, appStoreUrl)}
+                    onClick={() =>
+                      openKeenVpnAppStore(resolveAppStoreUrl(appStoreUrl))
+                    }
                   >
-                    {downloadAppButtonLabel}
+                    {getAppStoreInstallButtonLabel()}
                   </Button>
                 )}
               </CardContent>
@@ -793,13 +779,14 @@ const Account = () => {
                         </p>
                       </div>
                       <Button
-                        asChild
+                        type="button"
                         className="bg-gradient-primary text-primary-foreground hover:opacity-90 shadow-glow"
                         size="lg"
+                        onClick={() =>
+                          returnToKeenVpnAppAfterAuth(sessionToken, appStoreUrl)
+                        }
                       >
-                        <a href={buildAuthDeepLink(sessionToken)}>
-                          Return to KeenVPN App
-                        </a>
+                        Return to KeenVPN App
                       </Button>
                     </>
                   ) : (
@@ -977,30 +964,16 @@ const Account = () => {
                     <div className="space-y-3">
                       {showReturnToAppCta ? (
                         <Button
-                          asChild
+                          type="button"
                           className="w-full bg-gradient-primary text-primary-foreground shadow-glow hover:opacity-90"
                           size="lg"
+                          onClick={() => {
+                            markStripeAutoOpenDone();
+                            returnToKeenVpnAppAfterPayment(getSessionToken(), appStoreUrl);
+                          }}
                         >
-                          <a
-                            href={PAYMENT_SUCCESS_DEEP_LINK}
-                            onClick={(event) => {
-                              event.preventDefault();
-                              markStripeAutoOpenDone();
-                              returnToKeenVpnAppAfterPayment(getSessionToken());
-                            }}
-                          >
-                            <Smartphone className="mr-2 h-5 w-5" />
-                            {RETURN_TO_APP_LABEL}
-                          </a>
-                        </Button>
-                      ) : isStripeManageable ? (
-                        <Button
-                          onClick={() =>
-                            openAppOrAppStore(subscription, appStoreUrl)
-                          }
-                          className="w-full bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg"
-                        >
-                          {downloadAppButtonLabel}
+                          <Smartphone className="mr-2 h-5 w-5" />
+                          {RETURN_TO_APP_LABEL}
                         </Button>
                       ) : null}
 
@@ -1014,14 +987,6 @@ const Account = () => {
                         <History className="h-4 w-4 mr-2" />
                         View Billing History
                       </Button>
-
-                      {showOpenMacAppButton && macSessionToken ? (
-                        <Button asChild variant="outline" className="w-full">
-                          <a href={buildAuthDeepLink(macSessionToken)}>
-                            Open KeenVPN App
-                          </a>
-                        </Button>
-                      ) : null}
 
                       <Button
                         onClick={handleRefreshSubscription}
@@ -1084,13 +1049,6 @@ const Account = () => {
                       <History className="h-4 w-4 mr-2" />
                       Manage Subscriptions
                     </Button>
-                    {showOpenMacAppButton && macSessionToken ? (
-                      <Button asChild variant="outline" className="w-full">
-                        <a href={buildAuthDeepLink(macSessionToken)}>
-                          Open KeenVPN App
-                        </a>
-                      </Button>
-                    ) : null}
                     <Button
                       onClick={() => navigate("/subscribe")}
                       className="w-full bg-primary text-primary-foreground hover:bg-primary/90 shadow-lg"

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -61,7 +61,6 @@ import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
 import { UserInformationCard } from "@/components/UserInformationCard";
 import { SubscriptionCancellationControls } from "@/components/SubscriptionCancellationControls";
 import {
-  detectDevice,
   isAppDeepLinkSupported,
   getUnsupportedDeviceName,
 } from "@/lib/device-detection";
@@ -138,7 +137,6 @@ const Account = () => {
   );
 
   const isDeepLinkSupported = useMemo(() => isAppDeepLinkSupported(), []);
-  const isMacOS = useMemo(() => detectDevice() === "macos", []);
   const unsupportedDeviceName = useMemo(() => getUnsupportedDeviceName(), []);
 
   // ASWebAuthenticationSession detection

--- a/src/pages/PaymentSuccess.tsx
+++ b/src/pages/PaymentSuccess.tsx
@@ -16,7 +16,11 @@ import {
   getUnsupportedDeviceName,
 } from "@/lib/device-detection";
 import { useAppStoreUrl } from "@/hooks/use-app-store-url";
-import { PAYMENT_SUCCESS_DEEP_LINK } from "@/lib/keenvpn-deep-links";
+import {
+  isNativeAppWebSession,
+  openKeenVpnNativeApp,
+  PAYMENT_SUCCESS_DEEP_LINK,
+} from "@/lib/keenvpn-deep-links";
 import {
   getAppStoreInstallButtonLabel,
   resolveAppStoreUrl,
@@ -24,14 +28,24 @@ import {
 
 const PaymentSuccess = () => {
   const deepLinkSupported = useMemo(() => isAppDeepLinkSupported(), []);
+  const fromNativeApp = useMemo(() => isNativeAppWebSession(), []);
   const unsupportedDevice = useMemo(() => getUnsupportedDeviceName(), []);
   const appStoreUrl = useAppStoreUrl();
 
   // Always "Download" + App Store — not getAppDownloadButtonLabel (that shows "Open" for subscribers).
   const downloadButtonLabel = useMemo(() => getAppStoreInstallButtonLabel(), []);
 
+  const resolvedAppStoreUrl = useMemo(
+    () => resolveAppStoreUrl(appStoreUrl),
+    [appStoreUrl],
+  );
+
   const openAppStore = () => {
-    window.open(resolveAppStoreUrl(appStoreUrl), "_blank", "noopener,noreferrer");
+    window.open(resolvedAppStoreUrl, "_blank", "noopener,noreferrer");
+  };
+
+  const openNativeApp = () => {
+    openKeenVpnNativeApp(PAYMENT_SUCCESS_DEEP_LINK, resolvedAppStoreUrl);
   };
 
   return (
@@ -64,36 +78,37 @@ const PaymentSuccess = () => {
             </div>
 
             <div className="space-y-3">
-              {deepLinkSupported ? (
+              {fromNativeApp && deepLinkSupported ? (
                 <>
                   <Button
-                    asChild
+                    type="button"
                     className="w-full bg-gradient-primary text-primary-foreground shadow-glow hover:opacity-90"
                     size="lg"
+                    onClick={openNativeApp}
                   >
-                    <a href={PAYMENT_SUCCESS_DEEP_LINK}>
-                      <Smartphone className="mr-2 h-5 w-5" />
-                      Return to KeenVPN App
-                    </a>
+                    <Smartphone className="mr-2 h-5 w-5" />
+                    Return to KeenVPN App
                   </Button>
                   <p className="text-xs text-muted-foreground">
-                    Tap the button above to open KeenVPN. If nothing happens,
-                    open the app manually — your subscription is already active.
+                    Tap the button above to return to KeenVPN. Your subscription
+                    is already active.
                   </p>
-                  <div className="border-t border-border/60 pt-3">
-                    <p className="mb-2 text-sm text-muted-foreground">
-                      Don&apos;t have the app installed yet?
-                    </p>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="w-full"
-                      onClick={openAppStore}
-                    >
-                      <Download className="mr-2 h-4 w-4" />
-                      {downloadButtonLabel}
-                    </Button>
-                  </div>
+                </>
+              ) : deepLinkSupported ? (
+                <>
+                  <Button
+                    type="button"
+                    className="w-full bg-gradient-primary text-primary-foreground shadow-glow hover:opacity-90"
+                    size="lg"
+                    onClick={openAppStore}
+                  >
+                    <Download className="mr-2 h-5 w-5" />
+                    {downloadButtonLabel}
+                  </Button>
+                  <p className="text-xs text-muted-foreground">
+                    After installing, sign in with the same account you used for
+                    checkout. Your subscription will be ready to use.
+                  </p>
                 </>
               ) : (
                 <>

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -190,6 +190,7 @@ const SignIn = () => {
       return;
     }
 
+    setOtpCode("");
     storeSessionToken(result.sessionToken);
     localStorage.setItem("auth_provider", "email");
     sessionStorage.setItem("auth_provider", "email");


### PR DESCRIPTION
Only fire vpnkeen:// handoffs when the page was opened from the native app, remove open-app buttons from header/hero/account in regular browser sessions, and open the Mac/iOS App Store app directly via store URL schemes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->