### PR TITLE
Improve admin churn dashboards and signup_started attribution reliability

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -1981,8 +1981,13 @@ export interface AdminUserProfileQuestionSummary {
   distribution: AdminUserProfileAnswerDistribution[];
 }
 
+export type AdminUserProfileAudience = "all" | "billing";
+
 export interface AdminUserProfileSummary {
+  audience: AdminUserProfileAudience;
   totalUsers: number;
+  trialUsers: number;
+  paidUsers: number;
   profilesStarted: number;
   profilesCompleted: number;
   questions: AdminUserProfileQuestionSummary[];
@@ -2179,6 +2184,8 @@ export interface AdminChurnReport {
   startOfMonthActiveUsers: number;
   hardChurned: number;
   hardChurnRate: number;
+  churnedFromCancellation: number;
+  accountsDeleted: number;
   softChurned: number;
   softChurnRate: number;
   trialChurned: number;
@@ -2236,6 +2243,8 @@ export interface AdminWeeklyChurnReport {
   startOfWeekActiveUsers: number;
   churned: number;
   churnRate: number;
+  churnedFromCancellation: number;
+  accountsDeleted: number;
   autoRenewDisabled: number;
   autoRenewDisabledRate: number;
   subscriptionExpirations: number;
@@ -2253,6 +2262,8 @@ export interface AdminWeeklyChurnTrendPoint {
   startOfWeekActiveUsers: number;
   churned: number;
   churnRate: number;
+  churnedFromCancellation: number;
+  accountsDeleted: number;
   autoRenewDisabled: number;
   autoRenewDisabledRate: number;
   subscriptionExpirations: number;
@@ -2543,7 +2554,7 @@ const SIGNUP_STARTED_SESSION_KEY = "keen_signup_started_tracked";
 
 let signupStartedInFlight: Promise<void> | null = null;
 
-/** Fire-and-forget: records signup_started with stored first-touch UTMs (pre-account). */
+/** Records signup_started with stored first-touch UTMs (pre-account). */
 export async function recordSignupStarted(): Promise<void> {
   const payload = getUtmAttributionAuthPayload();
   if (!payload.utmAttribution) return;
@@ -2572,6 +2583,13 @@ export async function recordSignupStarted(): Promise<void> {
         },
       );
       if (!response.ok) return;
+
+      const data: unknown = await response.json().catch(() => ({}));
+      const tracked =
+        typeof data === "object" &&
+        data !== null &&
+        (data as { tracked?: boolean }).tracked === true;
+      if (!tracked) return;
 
       if (typeof window !== "undefined") {
         try {
@@ -2894,6 +2912,7 @@ export async function adminFetchReviewPromptSummary(params?: {
 }
 
 export async function adminFetchUserProfileSummary(params?: {
+  audience?: AdminUserProfileAudience;
   signal?: AbortSignal;
 }): Promise<{
   ok: boolean;
@@ -2901,10 +2920,18 @@ export async function adminFetchUserProfileSummary(params?: {
   error?: string;
 }> {
   try {
-    const response = await fetch(`${BACKEND_URL}/admin/user-profiles/summary`, {
+    const query = new URLSearchParams();
+    if (params?.audience && params.audience !== "all") {
+      query.set("audience", params.audience);
+    }
+    const suffix = query.toString() ? `?${query.toString()}` : "";
+    const response = await fetch(
+      `${BACKEND_URL}/admin/user-profiles/summary${suffix}`,
+      {
       credentials: "include",
       signal: params?.signal,
-    });
+      },
+    );
     const raw: unknown = await response.json().catch(() => ({}));
     if (!response.ok) {
       return {

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -94,6 +94,7 @@ export type {
   SignupSourceStatusResponse,
   AdminSignupSourceSummary,
   AdminUserProfileAnswerDistribution,
+  AdminUserProfileAudience,
   AdminUserProfileQuestionSummary,
   AdminUserProfileSummary,
 } from './backend';

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -143,9 +143,9 @@ const SignIn = () => {
   const sendOtp = async () => {
     if (!emailForOtp) return;
 
-    await recordSignupStarted();
     setOtpLoading(true);
     setOtpMessage("");
+    await recordSignupStarted();
     const result = await requestEmailOtp(emailForOtp);
     setOtpLoading(false);
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -124,12 +124,12 @@ const SignIn = () => {
 
   // Debounce sign-in to prevent double-clicks
   const [handleGoogleSignIn, isGoogleDebouncing] = useDebounce(async () => {
-    void recordSignupStarted();
+    await recordSignupStarted();
     await signIn("google");
   }, 2000);
 
   const [handleAppleSignIn, isAppleDebouncing] = useDebounce(async () => {
-    void recordSignupStarted();
+    await recordSignupStarted();
     await signIn("apple");
   }, 2000);
 
@@ -143,7 +143,7 @@ const SignIn = () => {
   const sendOtp = async () => {
     if (!emailForOtp) return;
 
-    void recordSignupStarted();
+    await recordSignupStarted();
     setOtpLoading(true);
     setOtpMessage("");
     const result = await requestEmailOtp(emailForOtp);

--- a/src/pages/Subscribe.tsx
+++ b/src/pages/Subscribe.tsx
@@ -20,6 +20,7 @@ import {
   fetchSubscriptionPlans,
   createCheckoutSession,
   getSessionToken,
+  recordSignupStarted,
   CHECKOUT_ERROR_SESSION_EXPIRED,
 } from "@/auth/backend";
 import { enterprisePlan } from "@/constants/pricing";
@@ -361,6 +362,7 @@ const Subscribe = () => {
   }, [planIdParam]);
 
   const handleSignIn = async () => {
+    await recordSignupStarted();
     const result = await signIn();
     if (result.success && result.shouldRedirect) {
       navigate(result.shouldRedirect);

--- a/src/pages/admin/AdminChurn.tsx
+++ b/src/pages/admin/AdminChurn.tsx
@@ -261,7 +261,11 @@ export default function AdminChurn() {
         <SummaryCard
           title="Lost subscribers"
           value={report ? `${report.hardChurned} (${pct(report.hardChurnRate)})` : "—"}
-          subtitle="Cancelled or expired this month"
+          subtitle={
+            report
+              ? `Lost this month: ${report.churnedFromCancellation} cancelled, ${report.accountsDeleted} deleted account${report.accountsDeleted === 1 ? "" : "s"}`
+              : "Cancelled, expired, or deleted account this month"
+          }
           loading={loading}
         />
         <SummaryCard

--- a/src/pages/admin/AdminChurnWeekly.tsx
+++ b/src/pages/admin/AdminChurnWeekly.tsx
@@ -50,29 +50,59 @@ function friendlyProvider(raw: string): string {
   }
 }
 
-function friendlyClientPlatform(raw: string): string {
+function friendlyClientPlatform(raw: string): { label: string; hint?: string } {
   switch (raw.toLowerCase()) {
     case "macos":
-      return "macOS";
+      return { label: "macOS" };
     case "ios":
-      return "iOS";
+      return { label: "iOS" };
+    case "no_vpn_sessions":
+      return {
+        label: "No VPN sessions",
+        hint: "No qualifying VPN sessions in the prior 90 days",
+      };
+    case "other_platform":
+      return {
+        label: "Other / unrecognized",
+        hint: "Had sessions, but not mostly iOS or macOS",
+      };
     case "unknown":
-      return "Unknown";
+      return {
+        label: "No VPN sessions",
+        hint: "Legacy bucket — no qualifying VPN sessions in the prior 90 days",
+      };
     default:
-      return raw;
+      return { label: raw };
   }
 }
 
-const trendChartConfig = {
-  churnRate: {
-    label: "Weekly churn %",
+type ChurnTrendMetric = "churned" | "auto_renew_off" | "expirations";
+
+const CHURN_TREND_METRICS: {
+  value: ChurnTrendMetric;
+  label: string;
+  dataKey: "churnRate" | "autoRenewDisabledRate" | "subscriptionExpirationsRate";
+  color: string;
+}[] = [
+  {
+    value: "churned",
+    label: "Churned",
+    dataKey: "churnRate",
     color: "hsl(var(--destructive))",
   },
-  autoRenewDisabledRate: {
-    label: "Auto-renew off %",
+  {
+    value: "auto_renew_off",
+    label: "Auto-renew off",
+    dataKey: "autoRenewDisabledRate",
     color: "hsl(var(--primary))",
   },
-} satisfies ChartConfig;
+  {
+    value: "expirations",
+    label: "Expirations",
+    dataKey: "subscriptionExpirationsRate",
+    color: "hsl(var(--chart-2))",
+  },
+];
 
 const SOURCE_OPTIONS: { value: AdminChurnSubscriptionSource; label: string }[] = [
   { value: "all", label: "All sources" },
@@ -85,6 +115,7 @@ export default function AdminChurnWeekly() {
   const [isoYear, setIsoYear] = useState(initial.isoYear);
   const [isoWeek, setIsoWeek] = useState(initial.isoWeek);
   const [source, setSource] = useState<AdminChurnSubscriptionSource>("all");
+  const [trendMetric, setTrendMetric] = useState<ChurnTrendMetric>("churned");
   const [report, setReport] = useState<AdminWeeklyChurnReport | null>(null);
   const [trend, setTrend] = useState<AdminWeeklyChurnTrendReport | null>(null);
   const [loading, setLoading] = useState(true);
@@ -155,8 +186,24 @@ export default function AdminChurnWeekly() {
         label: p.weekLabel,
         churnRate: p.churnRate,
         autoRenewDisabledRate: p.autoRenewDisabledRate,
+        subscriptionExpirationsRate: p.subscriptionExpirationsRate,
       })),
     [trend],
+  );
+
+  const selectedTrendMetric = CHURN_TREND_METRICS.find(
+    (option) => option.value === trendMetric,
+  ) ?? CHURN_TREND_METRICS[0];
+
+  const trendChartConfig = useMemo(
+    () =>
+      ({
+        [selectedTrendMetric.dataKey]: {
+          label: `${selectedTrendMetric.label} %`,
+          color: selectedTrendMetric.color,
+        },
+      }) satisfies ChartConfig,
+    [selectedTrendMetric],
   );
 
   const weekInputValue = `${isoYear}-W${String(isoWeek).padStart(2, "0")}`;
@@ -167,9 +214,9 @@ export default function AdminChurnWeekly() {
         <div>
           <h3 className="text-lg font-semibold tracking-tight">Weekly churn</h3>
           <p className="text-sm text-muted-foreground">
-            ISO week (Monday UTC). Churn rate = net lost subscribers ÷ active at
-            week start (users who switch billing source are not counted as
-            churned). Internal test accounts are excluded.
+            ISO week (Monday UTC). Churn = subscribers lost this week (cancellations
+            + account deletions) ÷ active at week start. Users who switch billing
+            source are not counted as churned. Internal test accounts are excluded.
           </p>
         </div>
         <div className="flex flex-wrap items-end gap-2">
@@ -232,7 +279,11 @@ export default function AdminChurnWeekly() {
         <SummaryCard
           title="Weekly churn"
           value={report ? `${report.churned} (${pct(report.churnRate)})` : "—"}
-          subtitle="Subscribers lost this week"
+          subtitle={
+            report
+              ? `Lost this week: ${report.churnedFromCancellation} cancelled, ${report.accountsDeleted} deleted account${report.accountsDeleted === 1 ? "" : "s"}`
+              : "Subscribers lost this week"
+          }
           loading={loading}
         />
         <SummaryCard
@@ -310,7 +361,9 @@ export default function AdminChurnWeekly() {
           <CardHeader>
             <CardTitle>Churn by client platform</CardTitle>
             <CardDescription>
-              Dominant VPN app platform (90-day session lookback).
+              Primary VPN app used in the 90 days before week end. &quot;No VPN
+              sessions&quot; means the subscriber had no recorded VPN connections in
+              that window (not the same as account deletion).
             </CardDescription>
           </CardHeader>
           <CardContent className="overflow-x-auto">
@@ -330,7 +383,19 @@ export default function AdminChurnWeekly() {
                     className="border-t border-border/60"
                   >
                     <td className="py-2 pr-4">
-                      {friendlyClientPlatform(row.clientPlatform)}
+                      {(() => {
+                        const platform = friendlyClientPlatform(row.clientPlatform);
+                        return (
+                          <div>
+                            <span>{platform.label}</span>
+                            {platform.hint ? (
+                              <p className="mt-0.5 text-xs text-muted-foreground">
+                                {platform.hint}
+                              </p>
+                            ) : null}
+                          </div>
+                        );
+                      })()}
                     </td>
                     <td className="py-2 pr-4 text-right tabular-nums">{row.churned}</td>
                     <td className="py-2 pr-4 text-right tabular-nums">
@@ -348,12 +413,32 @@ export default function AdminChurnWeekly() {
       ) : null}
 
       <Card>
-        <CardHeader>
-          <CardTitle>8-week trend</CardTitle>
-          <CardDescription>
-            Weekly churn vs auto-renew disabled (% of active subscribers at week
-            start).
-          </CardDescription>
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle>8-week trend</CardTitle>
+            <CardDescription>
+              {selectedTrendMetric.label} as % of active subscribers at week
+              start.
+            </CardDescription>
+          </div>
+          <div
+            className="flex flex-wrap gap-1 rounded-lg border border-border p-1"
+            role="group"
+            aria-label="Trend metric"
+          >
+            {CHURN_TREND_METRICS.map((option) => (
+              <Button
+                key={option.value}
+                type="button"
+                size="sm"
+                variant={trendMetric === option.value ? "default" : "ghost"}
+                className="h-8"
+                onClick={() => setTrendMetric(option.value)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
         </CardHeader>
         <CardContent>
           {loading ? (
@@ -369,15 +454,8 @@ export default function AdminChurnWeekly() {
                 <ChartTooltip content={<ChartTooltipContent />} />
                 <Line
                   type="monotone"
-                  dataKey="churnRate"
-                  stroke="var(--color-churnRate)"
-                  strokeWidth={2}
-                  dot={false}
-                />
-                <Line
-                  type="monotone"
-                  dataKey="autoRenewDisabledRate"
-                  stroke="var(--color-autoRenewDisabledRate)"
+                  dataKey={selectedTrendMetric.dataKey}
+                  stroke={`var(--color-${selectedTrendMetric.dataKey})`}
                   strokeWidth={2}
                   dot={false}
                 />

--- a/src/pages/admin/AdminChurnWeekly.tsx
+++ b/src/pages/admin/AdminChurnWeekly.tsx
@@ -433,6 +433,7 @@ export default function AdminChurnWeekly() {
                 size="sm"
                 variant={trendMetric === option.value ? "default" : "ghost"}
                 className="h-8"
+                aria-pressed={trendMetric === option.value}
                 onClick={() => setTrendMetric(option.value)}
               >
                 {option.label}

--- a/src/pages/admin/AdminConnectionEngagementWeekly.tsx
+++ b/src/pages/admin/AdminConnectionEngagementWeekly.tsx
@@ -487,6 +487,7 @@ export default function AdminConnectionEngagementWeekly() {
                 size="sm"
                 variant={trendMetric === option.value ? "default" : "ghost"}
                 className="h-8"
+                aria-pressed={trendMetric === option.value}
                 onClick={() => setTrendMetric(option.value)}
               >
                 {option.label}

--- a/src/pages/admin/AdminConnectionEngagementWeekly.tsx
+++ b/src/pages/admin/AdminConnectionEngagementWeekly.tsx
@@ -53,16 +53,62 @@ function formatDuration(seconds: number): string {
   return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
 }
 
-const trendChartConfig = {
-  activeUsers: {
+type EngagementTrendMetric =
+  | "active_users"
+  | "median_connections"
+  | "total_connections"
+  | "median_connection_time"
+  | "total_connection_time";
+
+const ENGAGEMENT_TREND_METRICS: {
+  value: EngagementTrendMetric;
+  label: string;
+  dataKey: string;
+  color: string;
+  formatValue: (value: number) => string;
+  allowDecimals: boolean;
+}[] = [
+  {
+    value: "active_users",
     label: "Active users",
+    dataKey: "activeUsers",
     color: "hsl(var(--primary))",
+    formatValue: (value) => String(Math.round(value)),
+    allowDecimals: false,
   },
-  totalConnections: {
-    label: "Total connections",
+  {
+    value: "median_connections",
+    label: "Median connections",
+    dataKey: "medianConnections",
     color: "hsl(var(--chart-2))",
+    formatValue: (value) => value.toFixed(2),
+    allowDecimals: true,
   },
-} satisfies ChartConfig;
+  {
+    value: "total_connections",
+    label: "Total connections",
+    dataKey: "totalConnections",
+    color: "hsl(var(--chart-3))",
+    formatValue: (value) => String(Math.round(value)),
+    allowDecimals: false,
+  },
+  {
+    value: "median_connection_time",
+    label: "Median connection time",
+    dataKey: "medianConnectionSeconds",
+    color: "hsl(var(--chart-4))",
+    formatValue: formatDuration,
+    allowDecimals: true,
+  },
+  {
+    value: "total_connection_time",
+    label: "Total connection time",
+    dataKey: "totalConnectionSeconds",
+    color: "hsl(var(--chart-5))",
+    formatValue: formatDuration,
+    allowDecimals: false,
+  },
+];
 
 const PLATFORM_OPTIONS = [
   { value: "", label: "All platforms" },
@@ -143,6 +189,8 @@ export default function AdminConnectionEngagementWeekly() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [trendWarning, setTrendWarning] = useState<string | null>(null);
+  const [trendMetric, setTrendMetric] =
+    useState<EngagementTrendMetric>("active_users");
   const activeRequest = useRef<AbortController | null>(null);
 
   const load = useCallback(
@@ -236,9 +284,27 @@ export default function AdminConnectionEngagementWeekly() {
       (trend?.points ?? []).map((p) => ({
         label: p.week_label,
         activeUsers: p.active_users,
+        medianConnections: p.median_connections_per_user,
         totalConnections: p.total_connections,
+        medianConnectionSeconds: p.median_connection_seconds,
+        totalConnectionSeconds: p.total_connection_seconds,
       })),
     [trend],
+  );
+
+  const selectedTrendMetric =
+    ENGAGEMENT_TREND_METRICS.find((option) => option.value === trendMetric) ??
+    ENGAGEMENT_TREND_METRICS[0];
+
+  const trendChartConfig = useMemo(
+    () =>
+      ({
+        [selectedTrendMetric.dataKey]: {
+          label: selectedTrendMetric.label,
+          color: selectedTrendMetric.color,
+        },
+      }) satisfies ChartConfig,
+    [selectedTrendMetric],
   );
 
   const wow = report?.week_over_week;
@@ -402,9 +468,31 @@ export default function AdminConnectionEngagementWeekly() {
       </div>
 
       <Card>
-        <CardHeader>
-          <CardTitle>8-week trend</CardTitle>
-          <CardDescription>Active users and total connections over time.</CardDescription>
+        <CardHeader className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <CardTitle>8-week trend</CardTitle>
+            <CardDescription>
+              {selectedTrendMetric.label} over time for the selected filters.
+            </CardDescription>
+          </div>
+          <div
+            className="flex flex-wrap gap-1 rounded-lg border border-border p-1"
+            role="group"
+            aria-label="Trend metric"
+          >
+            {ENGAGEMENT_TREND_METRICS.map((option) => (
+              <Button
+                key={option.value}
+                type="button"
+                size="sm"
+                variant={trendMetric === option.value ? "default" : "ghost"}
+                className="h-8"
+                onClick={() => setTrendMetric(option.value)}
+              >
+                {option.label}
+              </Button>
+            ))}
+          </div>
         </CardHeader>
         <CardContent>
           {loading ? (
@@ -418,19 +506,27 @@ export default function AdminConnectionEngagementWeekly() {
               <LineChart data={chartRows} margin={{ left: 8, right: 8, top: 8, bottom: 0 }}>
                 <CartesianGrid vertical={false} />
                 <XAxis dataKey="label" tickLine={false} axisLine={false} />
-                <YAxis tickLine={false} axisLine={false} allowDecimals={false} />
-                <ChartTooltip content={<ChartTooltipContent />} />
-                <Line
-                  type="monotone"
-                  dataKey="activeUsers"
-                  stroke="var(--color-activeUsers)"
-                  strokeWidth={2}
-                  dot={false}
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  allowDecimals={selectedTrendMetric.allowDecimals}
+                  tickFormatter={(value) =>
+                    selectedTrendMetric.formatValue(Number(value))
+                  }
+                />
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(value) =>
+                        selectedTrendMetric.formatValue(Number(value))
+                      }
+                    />
+                  }
                 />
                 <Line
                   type="monotone"
-                  dataKey="totalConnections"
-                  stroke="var(--color-totalConnections)"
+                  dataKey={selectedTrendMetric.dataKey}
+                  stroke={`var(--color-${selectedTrendMetric.dataKey})`}
                   strokeWidth={2}
                   dot={false}
                 />

--- a/src/pages/admin/AdminUserProfiles.tsx
+++ b/src/pages/admin/AdminUserProfiles.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   adminFetchUserProfileSummary,
+  type AdminUserProfileAudience,
   type AdminUserProfileQuestionSummary,
   type AdminUserProfileSummary,
 } from "@/auth";
+import { Button } from "@/components/ui/button";
 
 function formatPercent(numerator: number, denominator: number) {
   if (denominator <= 0) return "—";
@@ -16,6 +18,24 @@ function categoryLabel(category: string) {
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
 }
+
+const AUDIENCE_OPTIONS: {
+  value: AdminUserProfileAudience;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "all",
+    label: "All users",
+    description: "Every registered account",
+  },
+  {
+    value: "billing",
+    label: "Paying & trial",
+    description:
+      "Users with an active or trialing subscription, or a Stripe customer on file (added payment method)",
+  },
+];
 
 function QuestionBreakdown({
   question,
@@ -85,12 +105,13 @@ function QuestionBreakdown({
 }
 
 export default function AdminUserProfiles() {
+  const [audience, setAudience] = useState<AdminUserProfileAudience>("billing");
   const [summary, setSummary] = useState<AdminUserProfileSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const activeRequest = useRef<AbortController | null>(null);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (targetAudience: AdminUserProfileAudience) => {
     activeRequest.current?.abort();
     const controller = new AbortController();
     activeRequest.current = controller;
@@ -98,7 +119,10 @@ export default function AdminUserProfiles() {
     setLoading(true);
     setError(null);
 
-    const res = await adminFetchUserProfileSummary({ signal: controller.signal });
+    const res = await adminFetchUserProfileSummary({
+      audience: targetAudience,
+      signal: controller.signal,
+    });
 
     if (controller.signal.aborted || activeRequest.current !== controller) {
       return;
@@ -116,9 +140,13 @@ export default function AdminUserProfiles() {
   }, []);
 
   useEffect(() => {
-    void load();
+    void load(audience);
     return () => activeRequest.current?.abort();
-  }, [load]);
+  }, [load, audience]);
+
+  const selectedAudience =
+    AUDIENCE_OPTIONS.find((option) => option.value === audience) ??
+    AUDIENCE_OPTIONS[0];
 
   const completionRate = summary
     ? formatPercent(summary.profilesCompleted, summary.totalUsers)
@@ -130,7 +158,7 @@ export default function AdminUserProfiles() {
 
   return (
     <div className="space-y-8">
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h2 className="text-2xl font-bold">User profiles</h2>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -138,13 +166,36 @@ export default function AdminUserProfiles() {
             responses are shown here.
           </p>
         </div>
-        <button
-          type="button"
-          onClick={() => void load()}
-          className="rounded-md border border-border px-3 py-2 text-sm hover:bg-muted"
-        >
+        <Button type="button" variant="outline" onClick={() => void load(audience)}>
           Refresh
-        </button>
+        </Button>
+      </div>
+
+      <div className="space-y-3 rounded-lg border border-border p-4">
+        <div>
+          <p className="text-sm font-medium">Audience</p>
+          <p className="text-sm text-muted-foreground">
+            {selectedAudience.description}
+          </p>
+        </div>
+        <div
+          className="flex flex-wrap gap-1 rounded-lg border border-border p-1"
+          role="group"
+          aria-label="Profile audience"
+        >
+          {AUDIENCE_OPTIONS.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              size="sm"
+              variant={audience === option.value ? "default" : "ghost"}
+              className="h-8"
+              onClick={() => setAudience(option.value)}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
       </div>
 
       {error ? (
@@ -153,11 +204,29 @@ export default function AdminUserProfiles() {
         </div>
       ) : null}
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-6">
         <div className="rounded-lg border border-border p-4">
-          <p className="text-sm text-muted-foreground">Total users</p>
+          <p className="text-sm text-muted-foreground">Users in audience</p>
           <p className="mt-1 text-3xl font-semibold">
             {summary?.totalUsers ?? (loading ? "…" : 0)}
+          </p>
+        </div>
+        <div className="rounded-lg border border-border p-4">
+          <p className="text-sm text-muted-foreground">Trial users</p>
+          <p className="mt-1 text-3xl font-semibold">
+            {summary?.trialUsers ?? (loading ? "…" : 0)}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Active trialing subscription
+          </p>
+        </div>
+        <div className="rounded-lg border border-border p-4">
+          <p className="text-sm text-muted-foreground">Paid users</p>
+          <p className="mt-1 text-3xl font-semibold">
+            {summary?.paidUsers ?? (loading ? "…" : 0)}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Active paid subscription
           </p>
         </div>
         <div className="rounded-lg border border-border p-4">
@@ -166,7 +235,7 @@ export default function AdminUserProfiles() {
             {summary?.profilesStarted ?? (loading ? "…" : 0)}
           </p>
           <p className="mt-1 text-xs text-muted-foreground">
-            {loading ? "" : `${startRate} of users`}
+            {loading ? "" : `${startRate} of audience`}
           </p>
         </div>
         <div className="rounded-lg border border-border p-4">
@@ -175,7 +244,7 @@ export default function AdminUserProfiles() {
             {summary?.profilesCompleted ?? (loading ? "…" : 0)}
           </p>
           <p className="mt-1 text-xs text-muted-foreground">
-            {loading ? "" : `${completionRate} of users`}
+            {loading ? "" : `${completionRate} of audience`}
           </p>
         </div>
         <div className="rounded-lg border border-border p-4">
@@ -195,7 +264,7 @@ export default function AdminUserProfiles() {
         <div>
           <h3 className="text-lg font-semibold">Question breakdown</h3>
           <p className="text-sm text-muted-foreground">
-            Answer distributions across all users who responded to each question.
+            Answer distributions for the selected audience.
           </p>
         </div>
 
@@ -217,7 +286,7 @@ export default function AdminUserProfiles() {
         <div>
           <h3 className="text-lg font-semibold">Profile funnel events</h3>
           <p className="text-sm text-muted-foreground">
-            Server-side product events for profile interactions.
+            Server-side product events for profile interactions in this audience.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Add churn and connection engagement trend metric filters in admin weekly views.
- Show clearer churn platform labels and cancelled vs deleted account breakdowns (weekly + monthly).
- Add billing audience toggle and trial/paid user profile counts.
- Await `recordSignupStarted()` before auth on sign-in/subscribe when UTMs are present; only dedupe session after `tracked: true`.

## Test plan
- [ ] Admin Churn weekly/monthly cards show cancelled vs deleted breakdown.
- [ ] Weekly churn and connection engagement trend charts filter by selected metric.
- [ ] Admin User Profiles billing toggle shows trial/paid counts.
- [ ] UTM landing → sign-in records `signup_started` before OAuth (deploy with matching backend PR).
- [ ] Direct sign-in without UTMs has no perceptible delay.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->