### PR TITLE
Fix empty admin trend charts for non-primary metrics

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,13 @@ All colors MUST be HSL.
     --sidebar-border: 220 13% 91%;
 
     --sidebar-ring: 217.2 91.2% 59.8%;
+
+    /* Chart series colors (HSL components for hsl(var(--chart-N))) */
+    --chart-1: 21 90% 46%;
+    --chart-2: 203 47% 44%;
+    --chart-3: 217 62% 35%;
+    --chart-4: 21 90% 56%;
+    --chart-5: 203 47% 55%;
   }
 
   .dark {
@@ -120,6 +127,12 @@ All colors MUST be HSL.
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+
+    --chart-1: 210 40% 98%;
+    --chart-2: 203 47% 55%;
+    --chart-3: 217 62% 45%;
+    --chart-4: 21 90% 56%;
+    --chart-5: 173 58% 45%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add missing `--chart-1` through `--chart-5` CSS variables to the theme
- Fixes 8-week trend charts on Connection Engagement and Churn admin pages where only Active users (using `--primary`) rendered a visible line

## Root cause
Trend charts stroke lines with `hsl(var(--chart-N))`, but those tokens were never defined in `index.css`. Axes/grid rendered while line strokes were invalid/invisible.

## Test plan
- [ ] Open Admin → Connection Engagement → Weekly session KPIs
- [ ] Switch trend metric between Active users, Total connections, Median connections, etc.
- [ ] Confirm each metric shows a visible line with the API data
- [ ] Repeat on Admin → Churn → Weekly churn trend for non-primary metrics


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->