### PR TITLE
Harden perks profile summary UI

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -2251,7 +2251,7 @@ export interface AdminUserProfileSummary {
   profilesCompleted: number;
   questions: AdminUserProfileQuestionSummary[];
   analyticsEvents: { eventName: string; count: number }[];
-  completionSources: { source: string; count: number }[];
+  completionSources?: { source: string; count: number }[];
 }
 
 export interface AdminDomainInsightsMetrics {

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -313,7 +313,12 @@ const Perks = () => {
     setProfileSummaryLoading(true);
     const res = await getUserProfileInformation(session);
     setProfileSummaryLoading(false);
-    if (!res.success) return;
+    if (!res.success) {
+      setProfileIsComplete(false);
+      setProfileAnsweredCount(0);
+      setProfileQuestionCount(0);
+      return;
+    }
 
     applyProfileSummary(res.questions, res.answers, res.isComplete);
   }, [applyProfileSummary]);

--- a/src/pages/admin/AdminUserProfiles.tsx
+++ b/src/pages/admin/AdminUserProfiles.tsx
@@ -311,7 +311,7 @@ export default function AdminUserProfiles() {
             </div>
           ) : null}
           {!loading && (summary?.completionSources.length ?? 0) === 0 ? (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-muted-foreground sm:col-span-2 lg:col-span-4">
               No completion sources recorded yet.
             </p>
           ) : null}


### PR DESCRIPTION
## Summary
- Reset profile summary state when the Perks profile fetch fails
- Make the admin completion-source empty state span the grid
- Mark completionSources optional for compatibility with older backend responses

## Verification
- npm run build