### PR TITLE
feat(account): family and business plan upgrades and membership sharing UI

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -1906,6 +1906,7 @@ export async function upgradeSubscriptionToAnnual(
 export async function createBillingPortalSession(
   sessionToken: string,
   returnUrl: string,
+  options?: { intent?: "default" | "change_plan" },
 ): Promise<{ success: boolean; url?: string; error?: string }> {
   try {
     const response = await fetch(`${BACKEND_URL}/payment/stripe/portal`, {
@@ -1914,7 +1915,10 @@ export async function createBillingPortalSession(
         "Content-Type": "application/json",
         Authorization: `Bearer ${sessionToken}`,
       },
-      body: JSON.stringify({ returnUrl }),
+      body: JSON.stringify({
+        returnUrl,
+        ...(options?.intent ? { intent: options.intent } : {}),
+      }),
     });
 
     const data = await response.json();
@@ -4258,6 +4262,33 @@ export async function adminListMembershipSharing(params: {
   }
 }
 
+export async function adminMembershipSharingMetrics(): Promise<{
+  ok: boolean;
+  data?: unknown;
+  error?: string;
+}> {
+  try {
+    const response = await fetch(
+      `${BACKEND_URL}/admin/subscription/membership-sharing/metrics`,
+      { credentials: "include" },
+    );
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(raw, "Failed to load seat metrics"),
+      };
+    }
+    return { ok: true, data: raw };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error ? error.message : "Failed to load seat metrics",
+    };
+  }
+}
+
 export async function adminRevokeMembershipMember(
   subscriptionId: string,
   memberUserId: string,
@@ -4436,6 +4467,35 @@ export async function revokeMembershipMember(
     return {
       ok: false,
       error: error instanceof Error ? error.message : "Failed to remove member",
+    };
+  }
+}
+
+export async function resendMembershipInvite(
+  sessionToken: string,
+  inviteId: string,
+): Promise<{ ok: boolean; data?: unknown; error?: string }> {
+  try {
+    const response = await fetch(
+      `${BACKEND_URL}/membership-sharing/invites/${encodeURIComponent(inviteId)}/resend`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { Authorization: `Bearer ${sessionToken}` },
+      },
+    );
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(raw, "Failed to resend invite"),
+      };
+    }
+    return { ok: true, data: raw };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Failed to resend invite",
     };
   }
 }

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -50,6 +50,8 @@ export interface RawSubscription {
   customerId?: string;
   plan?: string;
   planName?: string;
+  planId?: string | null;
+  seatLimit?: number | null;
   cancelAtPeriodEnd?: boolean;
   subscriptionType?: string;
   accessRole?: "owner" | "linked" | "member";
@@ -155,6 +157,12 @@ function normalizeBackendAuthResponse(
   if (rawSubscription.showAnnualUpgradePrompt !== undefined) {
     normalizedSubscription.showAnnualUpgradePrompt =
       rawSubscription.showAnnualUpgradePrompt;
+  }
+  if (rawSubscription.planId !== undefined) {
+    normalizedSubscription.planId = rawSubscription.planId;
+  }
+  if (rawSubscription.seatLimit !== undefined && rawSubscription.seatLimit !== null) {
+    normalizedSubscription.seatLimit = rawSubscription.seatLimit;
   }
 
   // Only surface subscriptions with actionable statuses so that all auth

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -11,6 +11,8 @@ export interface SubscriptionData {
   endDate: string;
   customerId?: string;
   plan?: string;
+  planId?: string | null;
+  seatLimit?: number;
   cancelAtPeriodEnd?: boolean;
   subscriptionType?: string;
   currentPeriodStart?: string | null;

--- a/src/components/MembershipPlanUpgradeCard.tsx
+++ b/src/components/MembershipPlanUpgradeCard.tsx
@@ -28,6 +28,10 @@ export function MembershipPlanUpgradeCard({
     canUpgradeStripeToFamilyPlan(subscription) || tier === "individual";
   const showBusinessOption =
     canUpgradeStripeToBusinessPlan(subscription) || tier === "individual";
+  const portalOptionsCopy =
+    tier === "family"
+      ? "Stripe will show the Business upgrade option."
+      : "Stripe will show Family and Business options you can switch to.";
 
   return (
     <div className="space-y-3 rounded-lg border border-primary/25 bg-primary/5 p-4">
@@ -38,8 +42,8 @@ export function MembershipPlanUpgradeCard({
             Share KeenVPN with others
           </p>
           <p className="text-xs text-muted-foreground">
-            Upgrade your plan to invite members with their own logins. Stripe
-            will show Family and Business options you can switch to.
+            Upgrade your plan to invite members with their own logins.{" "}
+            {portalOptionsCopy}
           </p>
         </div>
       </div>

--- a/src/components/MembershipPlanUpgradeCard.tsx
+++ b/src/components/MembershipPlanUpgradeCard.tsx
@@ -1,0 +1,85 @@
+import { Button } from "@/components/ui/button";
+import { Loader2, Users } from "lucide-react";
+import type { SubscriptionData } from "@/auth/types";
+import {
+  canUpgradeStripeMembershipPlan,
+  canUpgradeStripeToBusinessPlan,
+  canUpgradeStripeToFamilyPlan,
+  resolveMembershipPlanTier,
+} from "@/lib/subscription-cta";
+
+interface MembershipPlanUpgradeCardProps {
+  subscription: SubscriptionData;
+  portalLoading?: boolean;
+  onUpgradePlan: () => void | Promise<void>;
+}
+
+export function MembershipPlanUpgradeCard({
+  subscription,
+  portalLoading = false,
+  onUpgradePlan,
+}: MembershipPlanUpgradeCardProps) {
+  if (!canUpgradeStripeMembershipPlan(subscription)) {
+    return null;
+  }
+
+  const tier = resolveMembershipPlanTier(subscription);
+  const showFamilyOption =
+    canUpgradeStripeToFamilyPlan(subscription) || tier === "individual";
+  const showBusinessOption =
+    canUpgradeStripeToBusinessPlan(subscription) || tier === "individual";
+
+  return (
+    <div className="space-y-3 rounded-lg border border-primary/25 bg-primary/5 p-4">
+      <div className="flex items-start gap-3">
+        <Users className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">
+            Share KeenVPN with others
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Upgrade your plan to invite members with their own logins. Stripe
+            will show Family and Business options you can switch to.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        {showFamilyOption ? (
+          <div className="rounded-md border border-border/80 bg-background/80 p-3">
+            <p className="text-sm font-medium">Family</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Up to 5 seats · invite by email
+            </p>
+          </div>
+        ) : null}
+        {showBusinessOption ? (
+          <div className="rounded-md border border-border/80 bg-background/80 p-3">
+            <p className="text-sm font-medium">Business</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Up to 10 seats · for teams
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      <Button
+        type="button"
+        className="w-full"
+        onClick={() => void onUpgradePlan()}
+        disabled={portalLoading}
+      >
+        {portalLoading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Opening Stripe…
+          </>
+        ) : tier === "family" ? (
+          "Upgrade to Business"
+        ) : (
+          "Upgrade plan"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/MembershipSharingCard.tsx
+++ b/src/components/MembershipSharingCard.tsx
@@ -232,7 +232,7 @@ export function MembershipSharingCard({
           </CardTitle>
           <CardDescription>
             Invite family or team members to share your KeenVPN Premium
-            subscription. Available on Family and Team plans.
+            subscription. Available on Family and Business plans.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/components/MembershipSharingCard.tsx
+++ b/src/components/MembershipSharingCard.tsx
@@ -12,9 +12,11 @@ import { Loader2, Users } from "lucide-react";
 import {
   fetchMembershipSharingDashboard,
   inviteMembershipMember,
+  resendMembershipInvite,
   revokeMembershipInvite,
   revokeMembershipMember,
 } from "@/auth/backend";
+import { Link } from "react-router-dom";
 
 interface MembershipSharingCardProps {
   sessionToken: string;
@@ -34,6 +36,12 @@ interface DashboardPendingInvite {
   expiresAt: string;
 }
 
+interface DashboardRevokedInvite {
+  id: string;
+  email: string;
+  revokedAt?: string | null;
+}
+
 interface DashboardData {
   role: string;
   eligible: boolean;
@@ -50,6 +58,7 @@ interface DashboardData {
   } | null;
   members: DashboardMember[];
   pendingInvites: DashboardPendingInvite[];
+  revokedInvites?: DashboardRevokedInvite[];
 }
 
 function formatDate(iso: string): string {
@@ -127,6 +136,21 @@ export function MembershipSharingCard({
       const res = await revokeMembershipMember(sessionToken, userId);
       if (!res.ok) {
         setError(res.error ?? "Could not remove member.");
+        return;
+      }
+      setDashboard(res.data as DashboardData);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleResendInvite(inviteId: string) {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await resendMembershipInvite(sessionToken, inviteId);
+      if (!res.ok) {
+        setError(res.error ?? "Could not resend invite.");
         return;
       }
       setDashboard(res.data as DashboardData);
@@ -213,9 +237,12 @@ export function MembershipSharingCard({
         </CardHeader>
         <CardContent>
           <p className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
-            Family sharing is not enabled on this subscription yet. Contact
-            support to add family access.
+            Upgrade to a Family or Business plan to invite members with their own
+            login credentials.
           </p>
+          <Button asChild className="mt-4" variant="outline">
+            <Link to="/pricing">View Family &amp; Business plans</Link>
+          </Button>
         </CardContent>
       </Card>
     );
@@ -318,14 +345,45 @@ export function MembershipSharingCard({
                       Expires {formatDate(invite.expiresAt)}
                     </p>
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void handleCancelInvite(invite.id)}
-                    disabled={submitting}
-                  >
-                    Cancel
-                  </Button>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void handleResendInvite(invite.id)}
+                      disabled={submitting}
+                    >
+                      Resend
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void handleCancelInvite(invite.id)}
+                      disabled={submitting}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {(dashboard.revokedInvites?.length ?? 0) > 0 ? (
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              Recently revoked invites
+            </h3>
+            <ul className="space-y-2">
+              {dashboard.revokedInvites?.map((invite) => (
+                <li
+                  key={invite.id}
+                  className="rounded-md border border-dashed p-3 text-sm text-muted-foreground"
+                >
+                  {invite.email}
+                  {invite.revokedAt
+                    ? ` · revoked ${formatDate(invite.revokedAt)}`
+                    : ""}
                 </li>
               ))}
             </ul>

--- a/src/hooks/use-subscription-billing-actions.ts
+++ b/src/hooks/use-subscription-billing-actions.ts
@@ -97,54 +97,71 @@ export function useSubscriptionBillingActions(
     }
   }, [requireSessionToken, toast, refreshSubscription]);
 
+  const openBillingPortalWithIntent = useCallback(
+    async (intent: "default" | "change_plan", token: string) => {
+      const portalWindow = window.open("about:blank", "_blank");
+      const popupBlocked = portalWindow === null;
+
+      try {
+        setPortalLoading(true);
+        const result = await createBillingPortalSession(
+          token,
+          resolveReturnUrl(),
+          { intent },
+        );
+
+        if (result.success && result.url) {
+          if (portalWindow && !portalWindow.closed) {
+            navigateExternalPortalTab(portalWindow, result.url);
+          } else if (popupBlocked) {
+            toast({
+              title: "Opening billing portal",
+              description:
+                "Your browser blocked a new tab. Opening Stripe in this window.",
+            });
+            window.location.assign(result.url);
+          } else {
+            window.location.assign(result.url);
+          }
+        } else {
+          portalWindow?.close();
+          toast({
+            title: "Unable to open billing portal",
+            description: result.error || "Please try again.",
+            variant: "destructive",
+          });
+        }
+      } catch {
+        portalWindow?.close();
+        toast({
+          title: "Something went wrong",
+          description: "Please try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setPortalLoading(false);
+      }
+    },
+    [resolveReturnUrl, toast],
+  );
+
   const openBillingPortal = useCallback(async () => {
     const token = requireSessionToken();
     if (!token) {
       return;
     }
 
-    // Open a tab synchronously on click so Safari does not block the portal URL
-    // after the async session fetch. Do not pass "noopener" to window.open — it
-    // returns null and breaks the popup workaround; null opener before redirect instead.
-    const portalWindow = window.open("about:blank", "_blank");
-    const popupBlocked = portalWindow === null;
+    await openBillingPortalWithIntent("default", token);
+  }, [requireSessionToken, openBillingPortalWithIntent]);
 
-    try {
-      setPortalLoading(true);
-      const result = await createBillingPortalSession(token, resolveReturnUrl());
-
-      if (result.success && result.url) {
-        if (portalWindow && !portalWindow.closed) {
-          navigateExternalPortalTab(portalWindow, result.url);
-        } else if (popupBlocked) {
-          toast({
-            title: "Opening billing portal",
-            description:
-              "Your browser blocked a new tab. Opening Stripe in this window.",
-          });
-          window.location.assign(result.url);
-        } else {
-          window.location.assign(result.url);
-        }
-      } else {
-        portalWindow?.close();
-        toast({
-          title: "Unable to open billing portal",
-          description: result.error || "Please try again.",
-          variant: "destructive",
-        });
-      }
-    } catch {
-      portalWindow?.close();
-      toast({
-        title: "Something went wrong",
-        description: "Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setPortalLoading(false);
+  const openPlanChangePortal = useCallback(async () => {
+    const token = requireSessionToken();
+    if (!token) {
+      return;
     }
-  }, [requireSessionToken, resolveReturnUrl, toast]);
+
+    await openBillingPortalWithIntent("change_plan", token);
+  }, [requireSessionToken, openBillingPortalWithIntent]);
 
   const upgradeToAnnualPlan = useCallback(async () => {
     const token = requireSessionToken();
@@ -194,6 +211,7 @@ export function useSubscriptionBillingActions(
     upgradingToAnnual,
     cancelSubscriptionAtPeriodEnd,
     openBillingPortal,
+    openPlanChangePortal,
     upgradeToAnnualPlan,
   };
 }

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -118,19 +118,19 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
     transformedPlans.push({
       monthlyId: monthly?.id,
       annualId: annual?.id,
-      name: isPremium
+        name: isPremium
         ? "Individual"
         : isFamily
           ? "Family"
           : isTeam
-            ? "Team"
+            ? "Business"
             : "Premium",
       description: isPremium
         ? "Perfect for personal use"
         : isFamily
           ? "Share premium with up to 5 members"
           : isTeam
-            ? "For small teams (up to 10 members)"
+            ? "For teams and businesses (up to 10 members)"
             : "Premium VPN service",
       monthlyPrice,
       annualPrice,
@@ -153,6 +153,7 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
       Individual: 0,
       Premium: 0,
       Family: 1,
+      Business: 2,
       Team: 2,
     };
     return (

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -51,12 +51,20 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
   const plansByType = apiPlans.reduce(
     (acc, plan) => {
       const id = plan.id.toLowerCase();
+      const isFamily =
+        id.includes("family") &&
+        !id.includes("family_plus") &&
+        !id.includes("familyplus");
+      const isTeam =
+        id.includes("team") ||
+        id.includes("business") ||
+        id.includes("family_plus") ||
+        id.includes("familyplus");
       const isPremium =
         id.includes("premium") &&
         !id.includes("family") &&
-        !id.includes("team");
-      const isFamily = id.includes("family");
-      const isTeam = id.includes("team");
+        !id.includes("team") &&
+        !id.includes("business");
       const key = isPremium
         ? "premium"
         : isFamily

--- a/src/lib/subscription-cta.test.ts
+++ b/src/lib/subscription-cta.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { SubscriptionData } from "@/auth/types";
+import {
+  canUpgradeStripeToBusinessPlan,
+  canUpgradeStripeToFamilyPlan,
+  resolveMembershipPlanTier,
+} from "@/lib/subscription-cta";
+
+function stripeSub(
+  overrides: Partial<SubscriptionData> = {},
+): SubscriptionData {
+  return {
+    status: "active",
+    endDate: "2027-01-01T00:00:00.000Z",
+    canManageBilling: true,
+    subscriptionType: "stripe",
+    cancelAtPeriodEnd: false,
+    ...overrides,
+  };
+}
+
+describe("membership plan tier helpers", () => {
+  it("resolves tiers from plan name or id", () => {
+    expect(
+      resolveMembershipPlanTier(
+        stripeSub({ plan: "Premium VPN - Monthly", planId: "premium_monthly" }),
+      ),
+    ).toBe("individual");
+    expect(
+      resolveMembershipPlanTier(
+        stripeSub({
+          plan: "KeenVPN Family - Annual",
+          planId: "family_yearly",
+        }),
+      ),
+    ).toBe("family");
+    expect(
+      resolveMembershipPlanTier(
+        stripeSub({
+          plan: "KeenVPN Business - Monthly",
+          planId: "team_monthly",
+        }),
+      ),
+    ).toBe("business");
+  });
+
+  it("detects stripe upgrade eligibility", () => {
+    const individual = stripeSub({
+      plan: "Premium VPN - Monthly",
+      planId: "premium_monthly",
+    });
+    const family = stripeSub({
+      plan: "KeenVPN Family - Monthly",
+      planId: "family_monthly",
+    });
+
+    expect(canUpgradeStripeToFamilyPlan(individual)).toBe(true);
+    expect(canUpgradeStripeToBusinessPlan(individual)).toBe(false);
+    expect(canUpgradeStripeToFamilyPlan(family)).toBe(false);
+    expect(canUpgradeStripeToBusinessPlan(family)).toBe(true);
+  });
+});

--- a/src/lib/subscription-cta.ts
+++ b/src/lib/subscription-cta.ts
@@ -158,3 +158,76 @@ export function getSubscriptionCtaLabel(
     ? START_FREE_TRIAL_NOW_LABEL
     : SUBSCRIBE_NOW_LABEL;
 }
+
+export type MembershipPlanTier = "individual" | "family" | "business";
+
+function hasPlanToken(value: string, token: string): boolean {
+  return new RegExp(`(^|[^a-z0-9])${token}([^a-z0-9]|$)`).test(value);
+}
+
+/** Resolve Individual / Family / Business from plan id or display name. */
+export function resolveMembershipPlanTier(
+  subscription: SubscriptionData | null | undefined,
+): MembershipPlanTier {
+  const raw = `${subscription?.planId ?? ""} ${subscription?.plan ?? ""}`
+    .trim()
+    .toLowerCase();
+  if (!raw) return "individual";
+
+  if (
+    hasPlanToken(raw, "team") ||
+    hasPlanToken(raw, "business") ||
+    hasPlanToken(raw, "family_plus") ||
+    hasPlanToken(raw, "familyplus")
+  ) {
+    return "business";
+  }
+  if (hasPlanToken(raw, "family")) {
+    return "family";
+  }
+  return "individual";
+}
+
+function isEligibleStripePlanManager(
+  subscription: SubscriptionData | null | undefined,
+): boolean {
+  if (
+    !subscription ||
+    subscription.canManageBilling !== true ||
+    !isStripeSubscription(subscription)
+  ) {
+    return false;
+  }
+  if (subscription.cancelAtPeriodEnd) return false;
+  const status = getSubscriptionStatus(subscription);
+  return status === "active" || status === "trialing";
+}
+
+/** Stripe owner on Individual — can upgrade to Family or Business via billing portal. */
+export function canUpgradeStripeToFamilyPlan(
+  subscription: SubscriptionData | null | undefined,
+): boolean {
+  return (
+    isEligibleStripePlanManager(subscription) &&
+    resolveMembershipPlanTier(subscription) === "individual"
+  );
+}
+
+/** Stripe owner on Family — can upgrade to Business via billing portal. */
+export function canUpgradeStripeToBusinessPlan(
+  subscription: SubscriptionData | null | undefined,
+): boolean {
+  return (
+    isEligibleStripePlanManager(subscription) &&
+    resolveMembershipPlanTier(subscription) === "family"
+  );
+}
+
+export function canUpgradeStripeMembershipPlan(
+  subscription: SubscriptionData | null | undefined,
+): boolean {
+  return (
+    canUpgradeStripeToFamilyPlan(subscription) ||
+    canUpgradeStripeToBusinessPlan(subscription)
+  );
+}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1059,7 +1059,7 @@ const Account = () => {
                           onCancel={() => void cancelSubscriptionAtPeriodEnd()}
                           onManageBilling={() => void openBillingPortal()}
                           portalLoading={portalLoading}
-                          showManageBilling
+                          showManageBilling={!showStripeUpgradeToAnnual}
                         />
                       ) : null}
 

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -58,6 +58,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { LinkedAccounts } from "@/components/LinkedAccounts";
 import { MembershipSharingCard } from "@/components/MembershipSharingCard";
+import { MembershipPlanUpgradeCard } from "@/components/MembershipPlanUpgradeCard";
 import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
 import { UserInformationCard } from "@/components/UserInformationCard";
 import { SubscriptionCancellationControls } from "@/components/SubscriptionCancellationControls";
@@ -118,6 +119,7 @@ const Account = () => {
     portalLoading,
     cancelSubscriptionAtPeriodEnd,
     openBillingPortal,
+    openPlanChangePortal,
   } = useSubscriptionBillingActions();
   const { upgrading, upgradeToAnnual } = useAnnualUpgrade();
   const [showContactEmailModal, setShowContactEmailModal] = useState(false);
@@ -914,6 +916,12 @@ const Account = () => {
                       </p>
                     </div>
 
+                    <MembershipPlanUpgradeCard
+                      subscription={subscription}
+                      portalLoading={portalLoading}
+                      onUpgradePlan={openPlanChangePortal}
+                    />
+
                     {/* Upgrade to Annual */}
                     {showStripeUpgradeInCard && (
                       <div className="space-y-2 rounded-lg border border-primary/20 bg-primary/5 p-3">
@@ -1051,7 +1059,7 @@ const Account = () => {
                           onCancel={() => void cancelSubscriptionAtPeriodEnd()}
                           onManageBilling={() => void openBillingPortal()}
                           portalLoading={portalLoading}
-                          showManageBilling={!showStripeUpgradeToAnnual}
+                          showManageBilling
                         />
                       ) : null}
 

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -28,8 +28,12 @@ import { PricingPlan } from "@/lib/pricing";
 import SEOHead from "@/components/SEOHead";
 import {
   canStartFreeTrial,
+  canUpgradeStripeMembershipPlan,
   canUpgradeStripeToAnnual,
+  resolveMembershipPlanTier,
 } from "@/lib/subscription-cta";
+import { MembershipPlanUpgradeCard } from "@/components/MembershipPlanUpgradeCard";
+import { useSubscriptionBillingActions } from "@/hooks/use-subscription-billing-actions";
 import type { TrialData } from "@/auth/types";
 import { MembershipTransferDialog } from "@/components/MembershipTransferDialog";
 import {
@@ -83,6 +87,13 @@ const Pricing = () => {
 
   const isMonthlyStripeUpgradeEligible =
     canUpgradeStripeToAnnual(subscription);
+
+  const showMembershipPlanUpgrade = canUpgradeStripeMembershipPlan(subscription);
+  const membershipTier = resolveMembershipPlanTier(subscription);
+
+  const { portalLoading, openPlanChangePortal } = useSubscriptionBillingActions({
+    returnUrl: typeof window !== "undefined" ? `${window.location.origin}/pricing` : undefined,
+  });
 
   const { upgrading, upgradeToAnnual, trackAnnualEvent } = useAnnualUpgrade();
   // annual_plan_viewed: once per page visit (default billing is annual on mount).
@@ -268,6 +279,18 @@ const Pricing = () => {
           </section>
         )}
 
+        {showMembershipPlanUpgrade && subscription ? (
+          <section className="container mx-auto px-4 mb-10">
+            <div className="max-w-3xl mx-auto">
+              <MembershipPlanUpgradeCard
+                subscription={subscription}
+                portalLoading={portalLoading}
+                onUpgradePlan={openPlanChangePortal}
+              />
+            </div>
+          </section>
+        ) : null}
+
         {/* Pricing Cards */}
         <section id="plans" className="container mx-auto px-4 mb-20">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-7xl mx-auto items-stretch">
@@ -284,6 +307,16 @@ const Pricing = () => {
               const annualBillingDetail = isAnnual
                 ? formatAnnualBillingDetail(plan)
                 : null;
+              const showFamilyPlanUpgrade =
+                ctaKind === "manage_account" &&
+                plan.name === "Family" &&
+                membershipTier === "individual" &&
+                showMembershipPlanUpgrade;
+              const showBusinessPlanUpgrade =
+                ctaKind === "manage_account" &&
+                plan.name === "Business" &&
+                membershipTier !== "business" &&
+                showMembershipPlanUpgrade;
 
               return (
                 <div
@@ -354,6 +387,29 @@ const Pricing = () => {
                         {plan.buttonText}
                       </Button>
                     </ContactSalesDialog>
+                  ) : showFamilyPlanUpgrade || showBusinessPlanUpgrade ? (
+                    <Button
+                      onClick={() => void openPlanChangePortal()}
+                      disabled={portalLoading}
+                      className={`w-full mb-6 ${
+                        plan.popular
+                          ? "bg-gradient-primary text-primary-foreground hover:opacity-90 shadow-glow"
+                          : "border-primary/50 hover:bg-primary/10"
+                      }`}
+                      variant={plan.popular ? "default" : "outline"}
+                      size="lg"
+                    >
+                      {portalLoading ? (
+                        <>
+                          <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          Opening Stripe…
+                        </>
+                      ) : showBusinessPlanUpgrade ? (
+                        "Upgrade to Business"
+                      ) : (
+                        "Upgrade to Family"
+                      )}
+                    </Button>
                   ) : ctaKind === "manage_account" &&
                     isMonthlyStripeUpgradeEligible &&
                     isAnnual ? (
@@ -664,11 +720,39 @@ const Pricing = () => {
             </h2>
             <p className="text-xl text-muted-foreground mb-8">
               {ctaKind === "manage_account"
-                ? "Manage billing, plan details, and settings in one place."
+                ? showMembershipPlanUpgrade
+                  ? "Upgrade your plan to share KeenVPN with family or your team."
+                  : "Manage billing, plan details, and settings in one place."
                 : ctaKind === "subscribe"
                   ? "Choose a plan and subscribe to get full protection."
                   : "Start your 1 month free trial today"}
             </p>
+            {ctaKind === "manage_account" && showMembershipPlanUpgrade ? (
+              <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+                <Button
+                  onClick={() => void openPlanChangePortal()}
+                  disabled={portalLoading}
+                  className="bg-gradient-primary text-primary-foreground hover:opacity-90 shadow-glow"
+                  size="lg"
+                >
+                  {portalLoading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Opening Stripe…
+                    </>
+                  ) : (
+                    "Upgrade plan"
+                  )}
+                </Button>
+                <Button
+                  onClick={() => navigate("/account")}
+                  variant="outline"
+                  size="lg"
+                >
+                  Manage account
+                </Button>
+              </div>
+            ) : (
             <Button
               onClick={() => {
                 if (ctaKind === "loading") return;
@@ -695,6 +779,7 @@ const Pricing = () => {
                 "Start free trial"
               )}
             </Button>
+            )}
             <p className="text-sm text-muted-foreground mt-4">
               {ctaKind === "manage_account"
                 ? "Questions? We are here to help."

--- a/src/pages/Subscribe.tsx
+++ b/src/pages/Subscribe.tsx
@@ -37,11 +37,29 @@ const isAnnualPlan = (plan: ApiPlan) => getPlanBillingPeriod(plan) === "year";
 
 const getPlanFamily = (plan: ApiPlan) => {
   const id = plan.id.toLowerCase();
-  if (id.includes("family")) return "family";
-  if (id.includes("team")) return "team";
+  if (id.includes("family") && !id.includes("family_plus") && !id.includes("familyplus")) {
+    return "family";
+  }
+  if (
+    id.includes("team") ||
+    id.includes("business") ||
+    id.includes("family_plus") ||
+    id.includes("familyplus")
+  ) {
+    return "team";
+  }
   if (id.includes("premium")) return "premium";
   return id.replace(/[-_]?(monthly|month|annual|yearly|year)$/, "");
 };
+
+const PLAN_TIER_OPTIONS = [
+  { id: "premium", label: "Individual" },
+  { id: "family", label: "Family" },
+  { id: "team", label: "Business" },
+] as const;
+
+const getTierLabel = (tier: string) =>
+  PLAN_TIER_OPTIONS.find((option) => option.id === tier)?.label ?? tier;
 
 const sortPlansByBillingPeriod = (plans: ApiPlan[]) => {
   const order = { month: 0, year: 1 };
@@ -75,6 +93,50 @@ const matchesRequestedPlan = (plan: ApiPlan, requestedPlanId: string) => {
     return !isAnnualPlan(plan) && plan.id.toLowerCase().includes("premium");
   }
   return false;
+};
+
+interface PlanTierSelectorProps {
+  tiers: string[];
+  selectedTier: string;
+  onSelect: (tier: string) => void;
+  className?: string;
+}
+
+const PlanTierSelector = ({
+  tiers,
+  selectedTier,
+  onSelect,
+  className = "",
+}: PlanTierSelectorProps) => {
+  if (tiers.length <= 1) return null;
+
+  return (
+    <div className={className}>
+      <p className="mb-2 text-sm font-medium text-foreground">Plan type</p>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {tiers.map((tier) => {
+          const isSelected = selectedTier === tier;
+          return (
+            <button
+              key={tier}
+              type="button"
+              onClick={() => onSelect(tier)}
+              className={`rounded-lg border px-4 py-3 text-left transition-all ${
+                isSelected
+                  ? "border-primary bg-primary/10 shadow-glow"
+                  : "border-border bg-background hover:border-primary/50"
+              }`}
+              aria-pressed={isSelected}
+            >
+              <div className="font-semibold text-foreground">
+                {getTierLabel(tier)}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 };
 
 interface PlanOptionSelectorProps {
@@ -139,6 +201,8 @@ const Subscribe = () => {
     PricingPlan | ApiPlan | null
   >(null);
   const [planOptions, setPlanOptions] = useState<ApiPlan[]>([]);
+  const [allPlans, setAllPlans] = useState<ApiPlan[]>([]);
+  const [selectedTier, setSelectedTier] = useState("premium");
   const [planLoading, setPlanLoading] = useState(true);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -293,6 +357,35 @@ const Subscribe = () => {
     }
   }, [user]);
 
+  const availableTiers = PLAN_TIER_OPTIONS.map((option) => option.id).filter(
+    (tier) => allPlans.some((plan) => getPlanFamily(plan) === tier),
+  );
+
+  const applyTierSelection = useCallback(
+    (tier: string, plans: ApiPlan[], preferredPlanId?: string | null) => {
+      const options = sortPlansByBillingPeriod(
+        plans.filter((plan) => getPlanFamily(plan) === tier),
+      );
+      const requestedPlan = preferredPlanId
+        ? options.find((plan) => matchesRequestedPlan(plan, preferredPlanId))
+        : null;
+      const defaultPlan =
+        requestedPlan ||
+        options.find((plan) => getPlanBillingPeriod(plan) === "month") ||
+        options[0] ||
+        null;
+
+      setSelectedTier(tier);
+      setPlanOptions(options);
+      setSelectedPlan(defaultPlan ?? enterprisePlan);
+    },
+    [],
+  );
+
+  const handleTierChange = (tier: string) => {
+    applyTierSelection(tier, allPlans);
+  };
+
   // Fetch available subscription plans. The subscribe page should show both
   // monthly and annual options, while still respecting a planId from /pricing.
   useEffect(() => {
@@ -304,40 +397,21 @@ const Subscribe = () => {
         const response = await fetchSubscriptionPlans();
 
         if (response.success && response.plans && response.plans.length > 0) {
+          setAllPlans(response.plans);
+
           const requestedReturnedPlan = planIdParam
             ? response.plans.find((plan) =>
                 matchesRequestedPlan(plan, planIdParam),
               )
             : null;
-          const premiumPlans = sortPlansByBillingPeriod(
-            response.plans.filter((plan) => getPlanFamily(plan) === "premium"),
-          );
-          const options = requestedReturnedPlan
-            ? sortPlansByBillingPeriod(
-                response.plans.filter(
-                  (plan) =>
-                    getPlanFamily(plan) ===
-                    getPlanFamily(requestedReturnedPlan),
-                ),
-              )
-            : premiumPlans.length > 0
-              ? premiumPlans
-              : sortPlansByBillingPeriod(response.plans);
-          const requestedPlan = planIdParam
-            ? options.find((plan) => matchesRequestedPlan(plan, planIdParam))
-            : null;
-          const defaultPlan =
-            requestedPlan ||
-            options.find((plan) => getPlanBillingPeriod(plan) === "month") ||
-            options[0];
+          const tierOrder = ["premium", "family", "team"];
+          const initialTier = requestedReturnedPlan
+            ? getPlanFamily(requestedReturnedPlan)
+            : tierOrder.find((tier) =>
+                response.plans.some((plan) => getPlanFamily(plan) === tier),
+              ) ?? "premium";
 
-          if (!defaultPlan) {
-            setSelectedPlan(enterprisePlan);
-            return;
-          }
-
-          setPlanOptions(options);
-          setSelectedPlan(defaultPlan);
+          applyTierSelection(initialTier, response.plans, planIdParam);
         } else {
           console.error("Failed to load plan:", response.error);
           if (planIdParam) {
@@ -360,7 +434,7 @@ const Subscribe = () => {
     };
 
     loadPlans();
-  }, [planIdParam]);
+  }, [planIdParam, applyTierSelection]);
 
   const handleSignIn = async () => {
     await recordSignupStarted();
@@ -541,6 +615,11 @@ const Subscribe = () => {
               </CardHeader>
               <CardContent>
                 <div className="space-y-3">
+                  <PlanTierSelector
+                    tiers={availableTiers}
+                    selectedTier={selectedTier}
+                    onSelect={handleTierChange}
+                  />
                   <PlanOptionSelector
                     plans={planOptions}
                     selectedPlan={selectedPlan}
@@ -599,6 +678,12 @@ const Subscribe = () => {
                 </div>
               </CardHeader>
               <CardContent>
+                <PlanTierSelector
+                  tiers={availableTiers}
+                  selectedTier={selectedTier}
+                  onSelect={handleTierChange}
+                  className="mb-6"
+                />
                 <PlanOptionSelector
                   plans={planOptions}
                   selectedPlan={selectedPlan}

--- a/src/pages/admin/AdminMembershipSharing.tsx
+++ b/src/pages/admin/AdminMembershipSharing.tsx
@@ -88,8 +88,13 @@ export default function AdminMembershipSharing() {
       setTotal(data.total ?? 0);
 
       const metricsRes = await adminMembershipSharingMetrics();
-      if (isCurrentRequest() && metricsRes.ok) {
-        setMetrics(metricsRes.data as MembershipSharingMetrics);
+      if (isCurrentRequest()) {
+        if (metricsRes.ok) {
+          setMetrics(metricsRes.data as MembershipSharingMetrics);
+        } else {
+          setMetrics(null);
+          setError(metricsRes.error ?? "Failed to load seat metrics");
+        }
       }
     } catch (error) {
       if (!isCurrentRequest()) return;

--- a/src/pages/admin/AdminMembershipSharing.tsx
+++ b/src/pages/admin/AdminMembershipSharing.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   adminListMembershipSharing,
+  adminMembershipSharingMetrics,
   adminRevokeMembershipMember,
   adminUpdateMembershipSeatLimit,
 } from "@/auth/backend";
@@ -13,6 +14,25 @@ interface MemberRow {
   email: string;
   displayName?: string | null;
   joinedAt: string;
+}
+
+interface MembershipSharingSeats {
+  seatLimit: number;
+  activeSeats: number;
+  availableSeats: number;
+  pendingInvites: number;
+}
+
+interface MembershipSharingMetrics {
+  totalSeatSubscriptions: number;
+  totalSeatsPurchased: number;
+  totalMembers: number;
+  totalPendingInvites: number;
+  averageSeatsPerAccount: number;
+  familyPlanCount: number;
+  businessPlanCount: number;
+  familyPlanRevenueUsd: number;
+  businessPlanRevenueUsd: number;
 }
 
 interface PendingInviteRow {
@@ -44,6 +64,7 @@ export default function AdminMembershipSharing() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [seatDraft, setSeatDraft] = useState<Record<string, string>>({});
+  const [metrics, setMetrics] = useState<MembershipSharingMetrics | null>(null);
   const refreshRequestRef = useRef(0);
 
   const canWrite = can("membership_sharing.write");
@@ -65,6 +86,11 @@ export default function AdminMembershipSharing() {
       const data = res.data as { items?: SharingRow[]; total?: number };
       setRows(data.items ?? []);
       setTotal(data.total ?? 0);
+
+      const metricsRes = await adminMembershipSharingMetrics();
+      if (isCurrentRequest() && metricsRes.ok) {
+        setMetrics(metricsRes.data as MembershipSharingMetrics);
+      }
     } catch (error) {
       if (!isCurrentRequest()) return;
       setError(
@@ -131,6 +157,49 @@ export default function AdminMembershipSharing() {
           Manage family access for active subscriptions ({total} total)
         </p>
       </div>
+
+      {metrics ? (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-500">
+              Seat subscriptions
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-white">
+              {metrics.totalSeatSubscriptions}
+            </p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-500">
+              Avg seats / account
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-white">
+              {metrics.averageSeatsPerAccount}
+            </p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-500">
+              Family plans
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-white">
+              {metrics.familyPlanCount}
+            </p>
+            <p className="text-xs text-slate-500">
+              ${metrics.familyPlanRevenueUsd.toFixed(2)} listed MRR
+            </p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-900/50 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-500">
+              Business plans
+            </p>
+            <p className="mt-1 text-2xl font-semibold text-white">
+              {metrics.businessPlanCount}
+            </p>
+            <p className="text-xs text-slate-500">
+              ${metrics.businessPlanRevenueUsd.toFixed(2)} listed MRR
+            </p>
+          </div>
+        </div>
+      ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
         <Input


### PR DESCRIPTION
## Summary
- Adds Individual/Family/Business tier selector on Subscribe, plan upgrade CTAs on Account and Pricing, and Stripe billing portal plan-change intent
- Polishes membership sharing card with resend invites, revoked invite display, and upgrade prompts for seat-limited plans
- Adds admin membership sharing metrics UI and `MembershipPlanUpgradeCard` component

## Test plan
- [ ] Subscribe page shows tier selector and routes to correct Stripe checkout URLs
- [ ] Account page shows upgrade card for Individual → Family/Business eligible users
- [ ] Pricing page upgrade CTAs open billing portal with plan change intent
- [ ] Membership sharing card: invite, resend, revoke, accept flows work against staging API
- [ ] Admin membership sharing metrics page loads and displays counts

## Dependencies
- Pairs with backend PR for `planId`, `seatLimit`, resend endpoint, and portal plan-change support

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->