### PR TITLE
feat(account): membership sharing and connected devices UI

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -5295,3 +5295,66 @@ export async function getLinkedProviders(sessionToken: string): Promise<{
   }
   return response.json();
 }
+
+export async function fetchDeviceConnectionsStatus(
+  sessionToken: string,
+): Promise<{ ok: boolean; data?: unknown; error?: string }> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/device-connections/status`, {
+      credentials: "include",
+      headers: { Authorization: `Bearer ${sessionToken}` },
+    });
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (response.status === 404) {
+      return { ok: false, error: "Device connection limits are not enabled" };
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(
+          raw,
+          "Failed to load connected devices",
+        ),
+      };
+    }
+    return { ok: true, data: raw };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to load connected devices",
+    };
+  }
+}
+
+export async function revokeDeviceConnection(
+  sessionToken: string,
+  deviceId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/device-connections/revoke`, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Authorization: `Bearer ${sessionToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ deviceId }),
+    });
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(raw, "Failed to remove device"),
+      };
+    }
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : "Failed to remove device",
+    };
+  }
+}

--- a/src/components/ConnectedDevicesCard.tsx
+++ b/src/components/ConnectedDevicesCard.tsx
@@ -55,6 +55,7 @@ export function ConnectedDevicesCard({
   const [loading, setLoading] = useState(true);
   const [submittingId, setSubmittingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [featureDisabled, setFeatureDisabled] = useState(false);
   const loadRequestRef = useRef(0);
 
   const load = useCallback(async () => {
@@ -64,15 +65,18 @@ export function ConnectedDevicesCard({
 
     setLoading(true);
     setError(null);
+    setFeatureDisabled(false);
     try {
       const res = await fetchDeviceConnectionsStatus(sessionToken);
       if (!isCurrentRequest()) return;
       if (!res.ok) {
         if (res.error?.includes("not enabled")) {
           setStatus(null);
+          setFeatureDisabled(true);
           return;
         }
         setError(res.error ?? "Could not load connected devices.");
+        setStatus(null);
         return;
       }
       setStatus(res.data as DeviceStatusData);
@@ -114,6 +118,26 @@ export function ConnectedDevicesCard({
         <CardContent className="flex items-center gap-2 text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading devices…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (featureDisabled) {
+    return null;
+  }
+
+  if (error && !status) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MonitorSmartphone className="h-5 w-5" />
+            Connected devices
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">{error}</p>
         </CardContent>
       </Card>
     );
@@ -161,9 +185,14 @@ export function ConnectedDevicesCard({
                   size="sm"
                   disabled={submittingId === device.id}
                   onClick={() => void handleRevoke(device.id)}
+                  aria-busy={submittingId === device.id}
                 >
                   {submittingId === device.id ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <>
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                      <span className="sr-only">Removing device</span>
+                      <span>Remove</span>
+                    </>
                   ) : (
                     "Remove"
                   )}

--- a/src/components/ConnectedDevicesCard.tsx
+++ b/src/components/ConnectedDevicesCard.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Loader2, MonitorSmartphone } from "lucide-react";
+import {
+  fetchDeviceConnectionsStatus,
+  revokeDeviceConnection,
+} from "@/auth/backend";
+
+interface ConnectedDevicesCardProps {
+  sessionToken: string;
+}
+
+interface DeviceRow {
+  id: string;
+  platform?: string | null;
+  lastSeenAt: string;
+  connected: boolean;
+}
+
+interface DeviceStatusData {
+  limit: number;
+  activeCount: number;
+  available: number;
+  devices: DeviceRow[];
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function platformLabel(platform?: string | null): string {
+  if (!platform?.trim()) return "Unknown device";
+  return platform;
+}
+
+export function ConnectedDevicesCard({
+  sessionToken,
+}: ConnectedDevicesCardProps) {
+  const [status, setStatus] = useState<DeviceStatusData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const loadRequestRef = useRef(0);
+
+  const load = useCallback(async () => {
+    const requestId = loadRequestRef.current + 1;
+    loadRequestRef.current = requestId;
+    const isCurrentRequest = () => loadRequestRef.current === requestId;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchDeviceConnectionsStatus(sessionToken);
+      if (!isCurrentRequest()) return;
+      if (!res.ok) {
+        if (res.error?.includes("not enabled")) {
+          setStatus(null);
+          return;
+        }
+        setError(res.error ?? "Could not load connected devices.");
+        return;
+      }
+      setStatus(res.data as DeviceStatusData);
+    } finally {
+      if (isCurrentRequest()) {
+        setLoading(false);
+      }
+    }
+  }, [sessionToken]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleRevoke(deviceId: string) {
+    setSubmittingId(deviceId);
+    setError(null);
+    try {
+      const res = await revokeDeviceConnection(sessionToken, deviceId);
+      if (!res.ok) {
+        setError(res.error ?? "Failed to remove device.");
+        return;
+      }
+      await load();
+    } finally {
+      setSubmittingId(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <MonitorSmartphone className="h-5 w-5" />
+            Connected devices
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading devices…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!status) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <MonitorSmartphone className="h-5 w-5" />
+          Connected devices
+        </CardTitle>
+        <CardDescription>
+          {status.activeCount} of {status.limit} devices connected ·{" "}
+          {status.available} available
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        {status.devices.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No registered devices yet. Devices appear here after you connect
+            from the KeenVPN app.
+          </p>
+        ) : (
+          <ul className="divide-y rounded-md border">
+            {status.devices.map((device) => (
+              <li
+                key={device.id}
+                className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+              >
+                <div>
+                  <p className="font-medium">{platformLabel(device.platform)}</p>
+                  <p className="text-sm text-muted-foreground">
+                    Last seen {formatDate(device.lastSeenAt)}
+                    {device.connected ? " · Connected now" : ""}
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={submittingId === device.id}
+                  onClick={() => void handleRevoke(device.id)}
+                >
+                  {submittingId === device.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    "Remove"
+                  )}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -81,71 +81,108 @@ export const allFeatures = [
   "Dedicated account manager",
 ];
 
-export const featureComparison = [
+export type FeatureComparisonRow = {
+  feature: string;
+  individual: string | boolean;
+  family: string | boolean;
+  team: string | boolean;
+  enterprise: string | boolean;
+};
+
+export const featureComparison: FeatureComparisonRow[] = [
   {
     feature: "Simultaneous device connections",
     individual: "Up to 10",
+    family: "Up to 12",
     team: "Up to 14",
     enterprise: "Custom",
   },
   {
     feature: "Bandwidth",
     individual: "Unlimited",
+    family: "Unlimited",
     team: "Unlimited",
     enterprise: "Unlimited",
   },
   {
     feature: "Military-grade encryption",
     individual: true,
+    family: true,
     team: true,
     enterprise: true,
   },
   {
     feature: "No-log policy",
     individual: true,
+    family: true,
     team: true,
     enterprise: true,
   },
   {
     feature: "Kill switch protection",
     individual: true,
+    family: true,
     team: true,
     enterprise: true,
   },
   {
     feature: "24/7 customer support",
     individual: true,
+    family: true,
     team: true,
     enterprise: true,
   },
   {
     feature: "Free trial duration",
     individual: "1 month",
+    family: "1 month",
     team: "1 month",
     enterprise: "1 month",
   },
   {
     feature: "Team management dashboard",
     individual: false,
+    family: false,
     team: true,
     enterprise: true,
   },
   {
     feature: "Priority support",
     individual: false,
+    family: false,
     team: true,
     enterprise: true,
   },
   {
     feature: "Custom security solutions",
     individual: false,
+    family: false,
     team: false,
     enterprise: true,
   },
   {
     feature: "Dedicated account manager",
     individual: false,
+    family: false,
     team: false,
     enterprise: true,
   },
 ];
+
+/** Map a rendered pricing plan name to its comparison-table column value. */
+export function featureComparisonValueForPlan(
+  planName: string,
+  row: FeatureComparisonRow,
+): string | boolean {
+  switch (planName) {
+    case "Family":
+      return row.family;
+    case "Business":
+    case "Team":
+      return row.team;
+    case "Enterprise":
+      return row.enterprise;
+    default:
+      return row.individual;
+  }
+}

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -16,7 +16,7 @@ export const enterprisePlan: PricingPlan = {
     { name: "Access to all server locations", included: true },
     { name: "Unlimited bandwidth", included: true },
     { name: "Military-grade encryption", included: true },
-    { name: "Unlimited device connections", included: true },
+    { name: "Custom simultaneous device policy", included: true },
     { name: "24/7 customer support", included: true },
     { name: "No-log policy guaranteed", included: true },
     { name: "Kill switch protection", included: true },
@@ -82,6 +82,12 @@ export const allFeatures = [
 ];
 
 export const featureComparison = [
+  {
+    feature: "Simultaneous device connections",
+    individual: "Up to 10",
+    team: "Up to 14",
+    enterprise: "Custom",
+  },
   {
     feature: "Bandwidth",
     individual: "Unlimited",

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -123,6 +123,21 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
         ? monthly.features
         : [];
 
+    const deviceConnectionFeature = {
+      name: isTeam
+        ? "Up to 14 simultaneous devices"
+        : isFamily
+          ? "Up to 12 simultaneous devices"
+          : "Up to 10 simultaneous devices",
+      included: true,
+      highlighted: true,
+    };
+
+    const mergedFeatures = [
+      deviceConnectionFeature,
+      ...features.filter((f) => !/simultaneous device/i.test(f.name)),
+    ];
+
     transformedPlans.push({
       monthlyId: monthly?.id,
       annualId: annual?.id,
@@ -148,7 +163,7 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
       annualSavingsPercent,
       annualYearlySavingsDisplay,
       annualSavingsLabel,
-      features,
+      features: mergedFeatures,
       buttonText: "Start Free Trial",
       popular: isFamily,
       monthlyPriceId: monthly?.priceId,

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -58,6 +58,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { LinkedAccounts } from "@/components/LinkedAccounts";
 import { MembershipSharingCard } from "@/components/MembershipSharingCard";
+import { ConnectedDevicesCard } from "@/components/ConnectedDevicesCard";
 import { MembershipPlanUpgradeCard } from "@/components/MembershipPlanUpgradeCard";
 import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
 import { UserInformationCard } from "@/components/UserInformationCard";
@@ -1127,6 +1128,12 @@ const Account = () => {
           {hasSessionToken && (
             <div className="mt-8">
               <MembershipSharingCard sessionToken={getSessionToken() ?? ""} />
+            </div>
+          )}
+
+          {hasSessionToken && (
+            <div className="mt-8">
+              <ConnectedDevicesCard sessionToken={getSessionToken() ?? ""} />
             </div>
           )}
 

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/accordion";
 import { ContactSalesDialog } from "@/components/ContactSalesForm";
 import PricingNoticeTooltip from "@/components/PricingNoticeTooltip";
-import { enterprisePlan, featureComparison, faqs } from "@/constants/pricing";
+import { enterprisePlan, featureComparison, featureComparisonValueForPlan, faqs } from "@/constants/pricing";
 import { fetchSubscriptionPlans } from "@/auth/backend";
 import { useAnnualUpgrade } from "@/hooks/use-annual-upgrade";
 import {
@@ -515,7 +515,12 @@ const Pricing = () => {
           <div className="max-w-6xl md:mx-auto overflow-x-auto -mx-4 px-4 md:px-0">
             <div className="min-w-[600px] bg-gradient-card rounded-xl border border-border p-4 md:p-6">
               {/* Table Header */}
-              <div className="grid grid-cols-3 gap-2 md:gap-4 mb-4 md:mb-6 pb-4 md:pb-6 border-b border-border">
+              <div
+                className="grid gap-2 md:gap-4 mb-4 md:mb-6 pb-4 md:pb-6 border-b border-border"
+                style={{
+                  gridTemplateColumns: `minmax(8rem, 1.4fr) repeat(${plans.length}, minmax(0, 1fr))`,
+                }}
+              >
                 <div className="text-muted-foreground font-medium text-sm md:text-base">
                   Features
                 </div>
@@ -557,38 +562,33 @@ const Pricing = () => {
               {featureComparison.map((row, index) => (
                 <div
                   key={index}
-                  className="grid grid-cols-3 gap-2 md:gap-4 py-3 md:py-4 border-b border-border/50 last:border-0"
+                  className="grid gap-2 md:gap-4 py-3 md:py-4 border-b border-border/50 last:border-0"
+                  style={{
+                    gridTemplateColumns: `minmax(8rem, 1.4fr) repeat(${plans.length}, minmax(0, 1fr))`,
+                  }}
                 >
                   <div className="text-foreground text-xs md:text-sm lg:text-base">
                     {row.feature}
                   </div>
-                  <div className="text-center text-muted-foreground">
-                    {typeof row.individual === "boolean" ? (
-                      row.individual ? (
-                        <Check className="h-4 w-4 md:h-5 md:w-5 text-primary inline-block" />
-                      ) : (
-                        <X className="h-4 w-4 md:h-5 md:w-5 text-muted-foreground/50 inline-block" />
-                      )
-                    ) : (
-                      <span className="text-xs md:text-sm">
-                        {row.individual}
-                      </span>
-                    )}
-                  </div>
-
-                  <div className="text-center text-muted-foreground">
-                    {typeof row.enterprise === "boolean" ? (
-                      row.enterprise ? (
-                        <Check className="h-4 w-4 md:h-5 md:w-5 text-primary inline-block" />
-                      ) : (
-                        <X className="h-4 w-4 md:h-5 md:w-5 text-muted-foreground/50 inline-block" />
-                      )
-                    ) : (
-                      <span className="text-xs md:text-sm">
-                        {row.enterprise}
-                      </span>
-                    )}
-                  </div>
+                  {plans.map((plan) => {
+                    const value = featureComparisonValueForPlan(plan.name, row);
+                    return (
+                      <div
+                        key={plan.name}
+                        className="text-center text-muted-foreground"
+                      >
+                        {typeof value === "boolean" ? (
+                          value ? (
+                            <Check className="h-4 w-4 md:h-5 md:w-5 text-primary inline-block" />
+                          ) : (
+                            <X className="h-4 w-4 md:h-5 md:w-5 text-muted-foreground/50 inline-block" />
+                          )
+                        ) : (
+                          <span className="text-xs md:text-sm">{value}</span>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               ))}
             </div>

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -93,7 +93,7 @@ const Support = () => {
         },
         {
           q: "How many devices can I use with one account?",
-          a: "KeenVPN supports multiple devices per account. You can use your subscription on up to 5 devices simultaneously, including macOS, iOS, Windows, and Android devices.",
+          a: "Device limits depend on your plan: Individual supports up to 10 simultaneous connections, Family up to 12, and Business or Family Plus up to 14 — competitive with leading VPN providers. Connect on macOS, iOS, Windows, and Android. Manage active devices from your account page or in the app settings.",
         },
       ],
     },

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -93,7 +93,7 @@ const Support = () => {
         },
         {
           q: "How many devices can I use with one account?",
-          a: "Device limits depend on your plan: Individual supports up to 10 simultaneous connections, Family up to 12, and Business or Family Plus up to 14 — competitive with leading VPN providers. Connect on macOS, iOS, Windows, and Android. Manage active devices from your account page or in the app settings.",
+          a: "Device limits depend on your plan: Individual supports up to 10 simultaneous connections, Family up to 12, and Business up to 14 — competitive with leading VPN providers. Connect on macOS, iOS, Windows, and Android. Manage active devices from your account page or in the app settings.",
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Family/business plan upgrades and membership sharing UI on Account
- Connected devices card to view and remove registered devices (device connection limits QA)
- Annual upgrade and billing UX fixes from prior review

## Test plan
- [ ] Account page shows membership sharing for eligible plans
- [ ] Connected devices card lists devices after app connect (with `DEVICE_CONNECTION_LIMITS_ENABLED=true`)
- [ ] Remove device updates list and backend revokes device
- [ ] Annual upgrade card and Manage Billing visibility behave correctly


Made with [Cursor](https://cursor.com)