### PR TITLE
feat(perks): Chase VIG workflow UI and Business per-seat plan

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -369,12 +369,14 @@ export type PerkCategory =
   | "ai_productivity"
   | "developer_tools"
   | "startup_growth"
-  | "remote_work";
+  | "remote_work"
+  | "finance";
 
 export type PerkRedemptionType =
   | "external_link"
   | "coupon_code"
-  | "invite_only";
+  | "invite_only"
+  | "workflow";
 
 export type PerkUserTab = "new" | "completed" | "snoozed" | "not_interested";
 
@@ -408,6 +410,8 @@ export interface PerkItem {
   /** Present on claimed coupon perks so the code stays visible on the card. */
   couponCode?: string;
   redemptionUrl?: string;
+  /** Workflow Engine type identifier for "workflow" redemption perks, e.g. "chase_signup". */
+  workflowType?: string;
 }
 
 export interface PerksListPayload {
@@ -465,6 +469,9 @@ export async function claimPerk(
   couponCode?: string;
   message?: string;
   error?: string;
+  /** Present when redemptionType is "workflow" — the auto-started/resumed workflow. */
+  workflowId?: string;
+  workflowState?: WorkflowState;
 }> {
   try {
     const response = await fetch(
@@ -507,6 +514,14 @@ export async function claimPerk(
           : undefined,
       message:
         typeof payload["message"] === "string" ? payload["message"] : undefined,
+      workflowId:
+        typeof payload["workflowId"] === "string"
+          ? payload["workflowId"]
+          : undefined,
+      workflowState:
+        typeof payload["workflowState"] === "string"
+          ? (payload["workflowState"] as WorkflowState)
+          : undefined,
     };
   } catch (error) {
     return {
@@ -1803,6 +1818,7 @@ export async function createCheckoutSession(
   planId: string,
   successUrl?: string,
   cancelUrl?: string,
+  seatCount?: number,
 ): Promise<CreateCheckoutResult> {
   try {
     const response = await fetch(`${BACKEND_URL}/payment/stripe/checkout`, {
@@ -1815,6 +1831,7 @@ export async function createCheckoutSession(
         planId,
         successUrl,
         cancelUrl,
+        ...(seatCount !== undefined ? { seatCount } : {}),
       }),
     });
 
@@ -3724,6 +3741,8 @@ export interface AdminPerk {
   clonedFromPerkId: string | null;
   audienceTargeting: AudienceTargeting;
   extensionDomains: ExtensionDomainRule[];
+  /** Workflow Engine type identifier for "workflow" redemption perks, e.g. "chase_signup". */
+  workflowType: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -3764,6 +3783,8 @@ export interface CreateAdminPerkPayload {
   redemptionType?: PerkRedemptionType;
   redemptionUrl?: string;
   couponCode?: string;
+  /** Workflow Engine type identifier — required when redemptionType is "workflow". */
+  workflowType?: string;
   accessLevel?: "free" | "paid" | "annual";
   isFeatured?: boolean;
   isActive?: boolean;
@@ -3784,6 +3805,7 @@ export type UpdateAdminPerkPayload = Partial<{
   redemptionType: PerkRedemptionType;
   redemptionUrl: string | null;
   couponCode: string | null;
+  workflowType: string | null;
   accessLevel: "free" | "paid" | "annual";
   isFeatured: boolean;
   isActive: boolean;
@@ -4542,6 +4564,42 @@ export async function revokeMembershipInvite(
     return {
       ok: false,
       error: error instanceof Error ? error.message : "Failed to cancel invite",
+    };
+  }
+}
+
+/**
+ * Buy/reduce seats on the caller's owned Business subscription (Slack/Devin-style seat
+ * management). Stripe prorates the difference immediately; the returned `seatLimit` reflects
+ * the new value right away, ahead of the webhook reconciliation.
+ */
+export async function updateMembershipSeatCount(
+  sessionToken: string,
+  quantity: number,
+): Promise<{ ok: boolean; data?: { seatLimit: number }; error?: string }> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/membership-sharing/seats`, {
+      method: "PATCH",
+      credentials: "include",
+      headers: {
+        Authorization: `Bearer ${sessionToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ quantity }),
+    });
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: extractBackendErrorMessage(raw, "Failed to update seat count"),
+      };
+    }
+    return { ok: true, data: raw as { seatLimit: number } };
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Error ? error.message : "Failed to update seat count",
     };
   }
 }
@@ -5438,8 +5496,40 @@ export interface WorkflowSummary {
   durationMs: number | null;
 }
 
+/** Mirrors backend WorkflowQuestionDefinition (workflow-question.types.ts) — richer
+ * than ProfileQuestion so clients can render email/text/multi-select fields with
+ * conditional visibility instead of hardcoding per-workflow UI. */
+export type WorkflowQuestionFieldType =
+  | "email"
+  | "text"
+  | "single_select"
+  | "multi_select";
+
+export interface WorkflowQuestionOption {
+  value: string;
+  label: string;
+}
+
+export interface WorkflowQuestionShowWhen {
+  questionKey: string;
+  values: string[];
+}
+
+export interface WorkflowQuestionDefinition {
+  key: string;
+  label: string;
+  type: WorkflowQuestionFieldType;
+  helpText?: string;
+  options?: WorkflowQuestionOption[];
+  allowOther?: boolean;
+  showWhen?: WorkflowQuestionShowWhen;
+}
+
 export interface WorkflowDetail extends WorkflowSummary {
   missingInputKeys: string[];
+  /** Full question metadata for every input this workflow type collects. Omitted for
+   * profile-backed workflow types, which fall back to the global ProfileQuestion catalog. */
+  inputQuestions?: WorkflowQuestionDefinition[];
 }
 
 export interface WorkflowStepRunData {
@@ -5569,5 +5659,137 @@ export async function cancelWorkflow(
     `/${workflowId}/cancel`,
     { method: "POST" },
     "Failed to cancel workflow",
+  );
+}
+
+// ---------------------------------------------------------------------
+// AI Orchestrator (Claude) — conversational client on top of the Workflow Engine
+// ---------------------------------------------------------------------
+
+export type AiConversationStatus = "ACTIVE" | "CLOSED";
+export type AiMessageRole = "USER" | "ASSISTANT" | "TOOL";
+
+export interface AiConversationSummary {
+  id: string;
+  title: string | null;
+  status: AiConversationStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AiMessageData {
+  id: string;
+  role: AiMessageRole;
+  content: string | null;
+  toolName: string | null;
+  toolInput: Record<string, unknown> | null;
+  toolResult: unknown;
+  isError: boolean;
+  createdAt: string;
+}
+
+export interface AiPendingApproval {
+  workflowId: string;
+  stepKey: string | null;
+}
+
+interface AiApiResult<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+}
+
+async function aiRequest<T>(
+  sessionToken: string,
+  path: string,
+  init: RequestInit,
+  fallbackError: string,
+): Promise<AiApiResult<T>> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/ai/conversations${path}`, {
+      credentials: "include",
+      ...init,
+      headers: {
+        Authorization: `Bearer ${sessionToken}`,
+        ...(init.body ? { "Content-Type": "application/json" } : {}),
+        ...init.headers,
+      },
+    });
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      // Only the base "/ai/conversations" list endpoint is used to detect
+      // whether the feature is enabled at all — mirrors workflowRequest's
+      // approach for the Workflow Engine's own feature flag.
+      if (response.status === 404 && path === "") {
+        return { ok: false, error: "AI assistant is not available" };
+      }
+      return { ok: false, error: extractBackendErrorMessage(raw, fallbackError) };
+    }
+    return { ok: true, data: raw as T };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : fallbackError,
+    };
+  }
+}
+
+export async function listAiConversations(
+  sessionToken: string,
+): Promise<AiApiResult<{ success: boolean; conversations: AiConversationSummary[] }>> {
+  return aiRequest(
+    sessionToken,
+    "",
+    { method: "GET" },
+    "Failed to load conversations",
+  );
+}
+
+export async function createAiConversation(
+  sessionToken: string,
+  title?: string,
+): Promise<AiApiResult<{ success: boolean; conversationId: string }>> {
+  return aiRequest(
+    sessionToken,
+    "",
+    { method: "POST", body: JSON.stringify(title ? { title } : {}) },
+    "Failed to start a new conversation",
+  );
+}
+
+export async function getAiConversation(
+  sessionToken: string,
+  conversationId: string,
+): Promise<
+  AiApiResult<{
+    success: boolean;
+    conversation: AiConversationSummary;
+    messages: AiMessageData[];
+  }>
+> {
+  return aiRequest(
+    sessionToken,
+    `/${conversationId}`,
+    { method: "GET" },
+    "Failed to load conversation",
+  );
+}
+
+export async function sendAiMessage(
+  sessionToken: string,
+  conversationId: string,
+  message: string,
+): Promise<
+  AiApiResult<{
+    success: boolean;
+    reply: string;
+    pendingApproval?: AiPendingApproval;
+  }>
+> {
+  return aiRequest(
+    sessionToken,
+    `/${conversationId}/messages`,
+    { method: "POST", body: JSON.stringify({ message }) },
+    "Failed to send message",
   );
 }

--- a/src/components/AiAssistantCard.tsx
+++ b/src/components/AiAssistantCard.tsx
@@ -83,6 +83,8 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
       if (detailRes.ok && detailRes.data) {
         setConversationId(activeConversation.id);
         setMessages(detailRes.data.messages);
+      } else {
+        setError(detailRes.error ?? "Could not load your conversation.");
       }
     }
 
@@ -129,8 +131,9 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
       const id = await ensureConversation();
       if (!id) return;
 
+      const optimisticId = `local-${Date.now()}`;
       const optimisticUserMessage: AiMessageData = {
-        id: `local-${Date.now()}`,
+        id: optimisticId,
         role: "USER",
         content: text,
         toolName: null,
@@ -144,6 +147,8 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
 
       const res = await sendAiMessage(sessionToken, id, text);
       if (!res.ok || !res.data) {
+        setMessages((current) => current.filter((m) => m.id !== optimisticId));
+        setDraft(text);
         setError(res.error ?? "Failed to send message");
         return;
       }

--- a/src/components/AiAssistantCard.tsx
+++ b/src/components/AiAssistantCard.tsx
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { AlertCircle, Bot, Loader2, Send, Sparkles } from "lucide-react";
+import {
+  createAiConversation,
+  getAiConversation,
+  listAiConversations,
+  sendAiMessage,
+  type AiMessageData,
+  type AiPendingApproval,
+} from "@/auth/backend";
+import { cn } from "@/lib/utils";
+
+interface AiAssistantCardProps {
+  sessionToken: string;
+}
+
+const SUGGESTIONS = [
+  "What can you help me with?",
+  "Help me sign up for Mercury",
+  "What's the status of my applications?",
+];
+
+function humanizeStepKey(key: string): string {
+  return key
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
+  const [loading, setLoading] = useState(true);
+  const [featureDisabled, setFeatureDisabled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<AiMessageData[]>([]);
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [pendingApproval, setPendingApproval] =
+    useState<AiPendingApproval | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const loadGeneration = useRef(0);
+
+  const load = useCallback(async () => {
+    const generation = ++loadGeneration.current;
+    setLoading(true);
+    setError(null);
+    setFeatureDisabled(false);
+
+    const listRes = await listAiConversations(sessionToken);
+    if (generation !== loadGeneration.current) return;
+
+    if (!listRes.ok || !listRes.data) {
+      if (listRes.error?.includes("not available")) {
+        setFeatureDisabled(true);
+      } else {
+        setError(listRes.error ?? "Could not load the AI assistant.");
+      }
+      setLoading(false);
+      return;
+    }
+
+    const activeConversation = listRes.data.conversations.find(
+      (c) => c.status === "ACTIVE",
+    );
+    if (activeConversation) {
+      const detailRes = await getAiConversation(
+        sessionToken,
+        activeConversation.id,
+      );
+      if (generation !== loadGeneration.current) return;
+      if (detailRes.ok && detailRes.data) {
+        setConversationId(activeConversation.id);
+        setMessages(detailRes.data.messages);
+      }
+    }
+    setLoading(false);
+  }, [sessionToken]);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      loadGeneration.current += 1;
+    };
+  }, [load]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  async function ensureConversation(): Promise<string | null> {
+    if (conversationId) return conversationId;
+    const res = await createAiConversation(sessionToken);
+    if (!res.ok || !res.data) {
+      setError(res.error ?? "Failed to start a conversation");
+      return null;
+    }
+    setConversationId(res.data.conversationId);
+    return res.data.conversationId;
+  }
+
+  async function handleSend(overrideText?: string) {
+    const text = (overrideText ?? draft).trim();
+    if (!text || sending) return;
+
+    setSending(true);
+    setError(null);
+    try {
+      const id = await ensureConversation();
+      if (!id) return;
+
+      const optimisticUserMessage: AiMessageData = {
+        id: `local-${Date.now()}`,
+        role: "USER",
+        content: text,
+        toolName: null,
+        toolInput: null,
+        toolResult: null,
+        isError: false,
+        createdAt: new Date().toISOString(),
+      };
+      setMessages((current) => [...current, optimisticUserMessage]);
+      setDraft("");
+
+      const res = await sendAiMessage(sessionToken, id, text);
+      if (!res.ok || !res.data) {
+        setError(res.error ?? "Failed to send message");
+        return;
+      }
+
+      setMessages((current) => [
+        ...current,
+        {
+          id: `local-${Date.now()}-reply`,
+          role: "ASSISTANT",
+          content: res.data.reply,
+          toolName: null,
+          toolInput: null,
+          toolResult: null,
+          isError: false,
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+      setPendingApproval(res.data.pendingApproval ?? null);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleSend();
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Sparkles className="h-5 w-5" />
+            AI Assistant
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (featureDisabled) {
+    return null;
+  }
+
+  const visibleMessages = messages.filter((m) => m.role !== "TOOL");
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Sparkles className="h-5 w-5" />
+          AI Assistant
+        </CardTitle>
+        <CardDescription>
+          Tell KeenVPN what you&apos;d like help with. We&apos;ll find the right
+          application and guide you through it. Nothing is ever submitted
+          without your explicit approval.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {pendingApproval && (
+          <div className="flex items-start gap-2 rounded-md bg-muted/40 p-3 text-sm">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden />
+            <p>
+              Your approval is needed for &quot;
+              {humanizeStepKey(pendingApproval.stepKey ?? "this step")}&quot;.
+              Head to{" "}
+              <a href="#applications" className="font-medium underline">
+                Applications
+              </a>{" "}
+              below to review and approve it.
+            </p>
+          </div>
+        )}
+
+        <ScrollArea className="h-80 rounded-md border">
+          <div className="space-y-3 p-4">
+            {visibleMessages.length === 0 ? (
+              <div className="space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  Ask me to help you complete a partner application, check on
+                  something in progress, or explain what KeenVPN can do for
+                  you.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {SUGGESTIONS.map((suggestion) => (
+                    <Button
+                      key={suggestion}
+                      variant="outline"
+                      size="sm"
+                      className="h-auto whitespace-normal py-1.5 text-left text-xs"
+                      onClick={() => void handleSend(suggestion)}
+                      disabled={sending}
+                    >
+                      {suggestion}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              visibleMessages.map((message) => (
+                <div
+                  key={message.id}
+                  className={cn(
+                    "flex items-start gap-2",
+                    message.role === "USER" ? "justify-end" : "justify-start",
+                  )}
+                >
+                  {message.role === "ASSISTANT" && (
+                    <Bot
+                      className="mt-1 h-4 w-4 shrink-0 text-muted-foreground"
+                      aria-hidden
+                    />
+                  )}
+                  <div
+                    className={cn(
+                      "max-w-[85%] whitespace-pre-wrap rounded-lg px-3 py-2 text-sm",
+                      message.role === "USER"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted",
+                    )}
+                  >
+                    {message.content}
+                  </div>
+                </div>
+              ))
+            )}
+            {sending && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Bot className="h-4 w-4" aria-hidden />
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                Thinking…
+              </div>
+            )}
+            <div ref={bottomRef} />
+          </div>
+        </ScrollArea>
+
+        <div className="flex items-end gap-2">
+          <Textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask KeenVPN to help with an application…"
+            className="min-h-[44px] resize-none"
+            rows={1}
+            disabled={sending}
+          />
+          <Button
+            size="icon"
+            onClick={() => void handleSend()}
+            disabled={sending || !draft.trim()}
+            aria-label="Send message"
+          >
+            {sending ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Send className="h-4 w-4" aria-hidden />
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/AiAssistantCard.tsx
+++ b/src/components/AiAssistantCard.tsx
@@ -14,11 +14,13 @@ import {
   createAiConversation,
   getAiConversation,
   listAiConversations,
+  listWorkflows,
   sendAiMessage,
   type AiMessageData,
   type AiPendingApproval,
 } from "@/auth/backend";
 import { cn } from "@/lib/utils";
+import { pendingApprovalFromWorkflows } from "@/lib/workflow-ui";
 
 interface AiAssistantCardProps {
   sessionToken: string;
@@ -83,6 +85,15 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
         setMessages(detailRes.data.messages);
       }
     }
+
+    const workflowsRes = await listWorkflows(sessionToken);
+    if (generation !== loadGeneration.current) return;
+    if (workflowsRes.ok && workflowsRes.data) {
+      setPendingApproval(
+        pendingApprovalFromWorkflows(workflowsRes.data.workflows),
+      );
+    }
+
     setLoading(false);
   }, [sessionToken]);
 

--- a/src/components/MembershipPlanUpgradeCard.tsx
+++ b/src/components/MembershipPlanUpgradeCard.tsx
@@ -1,12 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Loader2, Users } from "lucide-react";
 import type { SubscriptionData } from "@/auth/types";
-import {
-  canUpgradeStripeMembershipPlan,
-  canUpgradeStripeToBusinessPlan,
-  canUpgradeStripeToFamilyPlan,
-  resolveMembershipPlanTier,
-} from "@/lib/subscription-cta";
+import { canUpgradeStripeMembershipPlan } from "@/lib/subscription-cta";
 
 interface MembershipPlanUpgradeCardProps {
   subscription: SubscriptionData;
@@ -23,48 +18,26 @@ export function MembershipPlanUpgradeCard({
     return null;
   }
 
-  const tier = resolveMembershipPlanTier(subscription);
-  const showFamilyOption =
-    canUpgradeStripeToFamilyPlan(subscription) || tier === "individual";
-  const showBusinessOption =
-    canUpgradeStripeToBusinessPlan(subscription) || tier === "individual";
-  const portalOptionsCopy =
-    tier === "family"
-      ? "You'll see the Business upgrade option."
-      : "You'll see Family and Business options you can switch to.";
-
   return (
     <div className="space-y-3 rounded-lg border border-primary/25 bg-primary/5 p-4">
       <div className="flex items-start gap-3">
         <Users className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
         <div className="space-y-1">
           <p className="text-sm font-medium text-foreground">
-            Share KeenVPN with others
+            Share KeenVPN with your team
           </p>
           <p className="text-xs text-muted-foreground">
-            Upgrade your plan to invite members with their own logins.{" "}
-            {portalOptionsCopy}
+            Upgrade to Business to invite members with their own logins.
+            You'll choose how many seats to buy in the billing portal.
           </p>
         </div>
       </div>
 
-      <div className="grid gap-2 sm:grid-cols-2">
-        {showFamilyOption ? (
-          <div className="rounded-md border border-border/80 bg-background/80 p-3">
-            <p className="text-sm font-medium">Family</p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Up to 5 seats · invite by email
-            </p>
-          </div>
-        ) : null}
-        {showBusinessOption ? (
-          <div className="rounded-md border border-border/80 bg-background/80 p-3">
-            <p className="text-sm font-medium">Business</p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Up to 10 seats · for teams
-            </p>
-          </div>
-        ) : null}
+      <div className="rounded-md border border-border/80 bg-background/80 p-3">
+        <p className="text-sm font-medium">Business</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Buy seats for your whole team · 5 connected devices per seat
+        </p>
       </div>
 
       <Button
@@ -78,10 +51,8 @@ export function MembershipPlanUpgradeCard({
             <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             Opening billing…
           </>
-        ) : tier === "family" ? (
-          "Upgrade to Business"
         ) : (
-          "Upgrade plan"
+          "Upgrade to Business"
         )}
       </Button>
     </div>

--- a/src/components/MembershipSharingCard.tsx
+++ b/src/components/MembershipSharingCard.tsx
@@ -283,7 +283,10 @@ export function MembershipSharingCard({
     occupiedSeats,
   );
   const currentSeatLimit = seats?.seatLimit ?? seatFloor;
-  const effectiveDraftSeats = draftSeatCount ?? currentSeatLimit;
+  const effectiveDraftSeats = Math.max(
+    seatFloor,
+    draftSeatCount ?? currentSeatLimit,
+  );
   const seatsChanged = effectiveDraftSeats !== currentSeatLimit;
 
   return (

--- a/src/components/MembershipSharingCard.tsx
+++ b/src/components/MembershipSharingCard.tsx
@@ -17,7 +17,7 @@ import {
   revokeMembershipMember,
   updateMembershipSeatCount,
 } from "@/auth/backend";
-import { MIN_BUSINESS_SEATS } from "@/constants/pricing";
+import { MIN_BUSINESS_SEATS, MAX_BUSINESS_SEATS } from "@/constants/pricing";
 import { Link } from "react-router-dom";
 
 interface MembershipSharingCardProps {
@@ -332,9 +332,11 @@ export function MembershipSharingCard({
                 variant="outline"
                 size="icon"
                 className="h-8 w-8"
-                disabled={submitting}
+                disabled={submitting || effectiveDraftSeats >= MAX_BUSINESS_SEATS}
                 onClick={() =>
-                  setDraftSeatCount((count) => (count ?? currentSeatLimit) + 1)
+                  setDraftSeatCount((count) =>
+                    Math.min(MAX_BUSINESS_SEATS, (count ?? currentSeatLimit) + 1),
+                  )
                 }
               >
                 +

--- a/src/components/MembershipSharingCard.tsx
+++ b/src/components/MembershipSharingCard.tsx
@@ -15,7 +15,9 @@ import {
   resendMembershipInvite,
   revokeMembershipInvite,
   revokeMembershipMember,
+  updateMembershipSeatCount,
 } from "@/auth/backend";
+import { MIN_BUSINESS_SEATS } from "@/constants/pricing";
 import { Link } from "react-router-dom";
 
 interface MembershipSharingCardProps {
@@ -45,6 +47,8 @@ interface DashboardRevokedInvite {
 interface DashboardData {
   role: string;
   eligible: boolean;
+  canManageSeats?: boolean;
+  minSeats?: number;
   seats?: {
     seatLimit: number;
     activeSeats: number;
@@ -79,6 +83,7 @@ export function MembershipSharingCard({
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [draftSeatCount, setDraftSeatCount] = useState<number | null>(null);
   const loadRequestRef = useRef(0);
 
   const load = useCallback(async () => {
@@ -99,7 +104,9 @@ export function MembershipSharingCard({
         setError(res.error ?? "Could not load membership sharing.");
         return;
       }
-      setDashboard(res.data as DashboardData);
+      const data = res.data as DashboardData;
+      setDashboard(data);
+      setDraftSeatCount(data.seats?.seatLimit ?? null);
     } finally {
       if (isCurrentRequest()) {
         setLoading(false);
@@ -174,6 +181,25 @@ export function MembershipSharingCard({
     }
   }
 
+  async function handleUpdateSeats() {
+    if (draftSeatCount == null) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await updateMembershipSeatCount(
+        sessionToken,
+        draftSeatCount,
+      );
+      if (!res.ok) {
+        setError(res.error ?? "Could not update seat count.");
+        return;
+      }
+      await load();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   if (loading) {
     return (
       <Card>
@@ -231,17 +257,17 @@ export function MembershipSharingCard({
             Membership sharing
           </CardTitle>
           <CardDescription>
-            Invite family or team members to share your KeenVPN Premium
-            subscription. Available on Family and Business plans.
+            Invite team members to share your KeenVPN Business subscription.
+            Available on the Business plan.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <p className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
-            Upgrade to a Family or Business plan to invite members with their own
-            login credentials.
+            Upgrade to a Business plan to invite members with their own login
+            credentials.
           </p>
           <Button asChild className="mt-4" variant="outline">
-            <Link to="/pricing">View Family &amp; Business plans</Link>
+            <Link to="/pricing">View Business plan</Link>
           </Button>
         </CardContent>
       </Card>
@@ -250,7 +276,15 @@ export function MembershipSharingCard({
 
   const seats = dashboard.seats;
   const hasAvailableSeats = (seats?.availableSeats ?? 0) > 0;
-  const isSingleSeatSubscription = (seats?.seatLimit ?? 1) <= 1;
+  const occupiedSeats =
+    (seats?.activeSeats ?? 0) + (seats?.pendingInvites ?? 0);
+  const seatFloor = Math.max(
+    dashboard.minSeats ?? MIN_BUSINESS_SEATS,
+    occupiedSeats,
+  );
+  const currentSeatLimit = seats?.seatLimit ?? seatFloor;
+  const effectiveDraftSeats = draftSeatCount ?? currentSeatLimit;
+  const seatsChanged = effectiveDraftSeats !== currentSeatLimit;
 
   return (
     <Card>
@@ -268,6 +302,60 @@ export function MembershipSharingCard({
       <CardContent className="space-y-6">
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
+        {dashboard.canManageSeats && seats ? (
+          <div className="space-y-2 rounded-md border bg-muted/30 p-4">
+            <h3 className="text-sm font-medium">Manage seats</h3>
+            <p className="text-xs text-muted-foreground">
+              Add or remove seats on your Business subscription. Stripe prorates
+              changes immediately.
+            </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                disabled={submitting || effectiveDraftSeats <= seatFloor}
+                onClick={() =>
+                  setDraftSeatCount((count) =>
+                    Math.max(seatFloor, (count ?? currentSeatLimit) - 1),
+                  )
+                }
+              >
+                −
+              </Button>
+              <span className="min-w-[2rem] text-center text-lg font-semibold">
+                {effectiveDraftSeats}
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                disabled={submitting}
+                onClick={() =>
+                  setDraftSeatCount((count) => (count ?? currentSeatLimit) + 1)
+                }
+              >
+                +
+              </Button>
+              <Button
+                onClick={() => void handleUpdateSeats()}
+                disabled={submitting || !seatsChanged}
+                size="sm"
+              >
+                {submitting ? "Updating…" : "Update seats"}
+              </Button>
+            </div>
+            {effectiveDraftSeats <= occupiedSeats ? (
+              <p className="text-xs text-muted-foreground">
+                Remove members or cancel pending invites before reducing below{" "}
+                {occupiedSeats} seats.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
         {hasAvailableSeats ? (
           <div className="space-y-2">
             <label
@@ -280,7 +368,7 @@ export function MembershipSharingCard({
               <Input
                 id="membership-invite-email"
                 type="email"
-                placeholder="family@example.com"
+                placeholder="teammate@example.com"
                 value={inviteEmail}
                 onChange={(e) => setInviteEmail(e.target.value)}
                 disabled={submitting}
@@ -295,9 +383,9 @@ export function MembershipSharingCard({
           </div>
         ) : (
           <p className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
-            {isSingleSeatSubscription
-              ? "Family sharing is not enabled on this subscription yet. Contact support to add family access."
-              : "All seats are currently used. Remove a member or cancel a pending invite to free a seat."}
+            {currentSeatLimit <= 1
+              ? "Membership sharing is not enabled on this subscription. Upgrade to Business to invite team members."
+              : "All seats are currently used. Remove a member, cancel a pending invite, or add more seats."}
           </p>
         )}
 

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -483,7 +483,9 @@ export function WorkflowPerkDialog({
         )}
 
         <DialogFooter>
-          {workflow && CANCELLABLE_STATES.includes(workflow.state) ? (
+          {workflow &&
+          CANCELLABLE_STATES.includes(workflow.state) &&
+          workflow.state !== "WAITING_FOR_APPROVAL" ? (
             <Button
               variant="ghost"
               className="text-muted-foreground"

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -10,6 +10,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import {
   approveWorkflowStep,
@@ -21,9 +23,10 @@ import {
   type WorkflowStepRunData,
 } from "@/auth/backend";
 import {
-  isWorkflowQuestionVisible,
   WorkflowQuestionField,
+  getVisibleWorkflowQuestionKeys,
 } from "@/components/WorkflowQuestionFields";
+import { humanizeWorkflowKey } from "@/lib/workflow-ui";
 import { useToast } from "@/hooks/use-toast";
 import { trackPerksEvent } from "@/lib/product-analytics";
 
@@ -172,8 +175,7 @@ export function WorkflowPerkDialog({
       }, POLL_INTERVAL_MS);
     }
     return clearPoll;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, detail?.workflow.state, workflowId]);
+  }, [open, detail?.workflow.state, workflowId, load, clearPoll]);
 
   useEffect(() => {
     const keys = new Set(detail?.workflow.missingInputKeys ?? []);
@@ -206,28 +208,11 @@ export function WorkflowPerkDialog({
 
   const visibleQuestionKeys = useMemo(() => {
     if (!detail) return [];
-    const missing = detail.workflow.missingInputKeys;
-    const inputQuestions = detail.workflow.inputQuestions;
-    if (!inputQuestions?.length) return missing;
-    const seen = new Set<string>();
-    const ordered: string[] = [];
-    for (const question of inputQuestions) {
-      if (
-        !seen.has(question.key) &&
-        (missing.includes(question.key) ||
-          isWorkflowQuestionVisible(question, answers))
-      ) {
-        seen.add(question.key);
-        ordered.push(question.key);
-      }
-    }
-    for (const key of missing) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        ordered.push(key);
-      }
-    }
-    return ordered;
+    return getVisibleWorkflowQuestionKeys({
+      missingInputKeys: detail.workflow.missingInputKeys,
+      inputQuestions: detail.workflow.inputQuestions,
+      answers,
+    });
   }, [detail, answers]);
 
   async function handleSubmitInputs() {
@@ -297,6 +282,7 @@ export function WorkflowPerkDialog({
         workflowId: detail.workflow.id,
       });
       toast({ title: "Application cancelled" });
+      onSettled?.();
       onOpenChange(false);
     } finally {
       setSubmitting(false);
@@ -379,18 +365,37 @@ export function WorkflowPerkDialog({
                   const question = workflow.inputQuestions?.find(
                     (q) => q.key === key,
                   );
-                  if (!question) return null;
+                  if (question) {
+                    return (
+                      <WorkflowQuestionField
+                        key={key}
+                        question={question}
+                        value={answers[key] ?? ""}
+                        onChange={(value) =>
+                          setAnswers((current) => ({ ...current, [key]: value }))
+                        }
+                        disabled={submitting}
+                        idPrefix="perk-workflow"
+                      />
+                    );
+                  }
                   return (
-                    <WorkflowQuestionField
-                      key={key}
-                      question={question}
-                      value={answers[key] ?? ""}
-                      onChange={(value) =>
-                        setAnswers((current) => ({ ...current, [key]: value }))
-                      }
-                      disabled={submitting}
-                      idPrefix="perk-workflow"
-                    />
+                    <div key={key} className="space-y-2">
+                      <Label htmlFor={`perk-workflow-${key}`}>
+                        {humanizeWorkflowKey(key)}
+                      </Label>
+                      <Input
+                        id={`perk-workflow-${key}`}
+                        value={answers[key] ?? ""}
+                        onChange={(e) =>
+                          setAnswers((current) => ({
+                            ...current,
+                            [key]: e.target.value,
+                          }))
+                        }
+                        disabled={submitting}
+                      />
+                    </div>
                   );
                 })}
                 <Button

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -1,0 +1,504 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+import {
+  approveWorkflowStep,
+  cancelWorkflow,
+  getWorkflow,
+  submitWorkflowInputs,
+  type WorkflowDetailResult,
+  type WorkflowState,
+  type WorkflowStepRunData,
+} from "@/auth/backend";
+import {
+  isWorkflowQuestionVisible,
+  WorkflowQuestionField,
+} from "@/components/WorkflowQuestionFields";
+import { useToast } from "@/hooks/use-toast";
+import { trackPerksEvent } from "@/lib/product-analytics";
+
+/** States that progress on their own (via cron/engine) — worth polling for updates.
+ * Mirrors WorkflowsCard.tsx AUTO_PROGRESS_STATES. */
+const AUTO_PROGRESS_STATES: WorkflowState[] = [
+  "CREATED",
+  "READY_TO_EXECUTE",
+  "EXECUTING",
+];
+
+const CANCELLABLE_STATES: WorkflowState[] = [
+  "CREATED",
+  "WAITING_FOR_INPUT",
+  "READY_TO_EXECUTE",
+  "WAITING_FOR_APPROVAL",
+];
+
+const POLL_INTERVAL_MS = 4000;
+
+function humanize(key: string): string {
+  return key
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function stateBadge(
+  state: WorkflowState,
+): { label: string; variant: "default" | "secondary" | "destructive" | "outline" } {
+  switch (state) {
+    case "COMPLETED":
+      return { label: "Completed", variant: "default" };
+    case "FAILED":
+      return { label: "Failed", variant: "destructive" };
+    case "CANCELLED":
+      return { label: "Cancelled", variant: "outline" };
+    case "WAITING_FOR_INPUT":
+      return { label: "Needs info", variant: "secondary" };
+    case "WAITING_FOR_APPROVAL":
+      return { label: "Needs approval", variant: "secondary" };
+    default:
+      return { label: "In progress", variant: "secondary" };
+  }
+}
+
+function stepIcon(step: WorkflowStepRunData) {
+  if (step.status === "COMPLETED") {
+    return <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden />;
+  }
+  if (step.status === "FAILED") {
+    return <XCircle className="h-4 w-4 text-destructive" aria-hidden />;
+  }
+  if (step.status === "RUNNING") {
+    return (
+      <Loader2
+        className="h-4 w-4 animate-spin text-muted-foreground"
+        aria-hidden
+      />
+    );
+  }
+  return (
+    <span
+      className="h-4 w-4 rounded-full border border-muted-foreground/40"
+      aria-hidden
+    />
+  );
+}
+
+interface WorkflowPerkDialogProps {
+  open: boolean;
+  sessionToken: string;
+  workflowId: string | null;
+  perkTitle: string;
+  onOpenChange: (open: boolean) => void;
+  /** Called after the workflow completes/is cancelled so the Perks list can refresh. */
+  onSettled?: () => void;
+}
+
+/** Renders a Chase-style VIG questionnaire + step tracker as a dialog on the Perks page,
+ * reusing the same field/step rendering as the account-dashboard WorkflowsCard. */
+export function WorkflowPerkDialog({
+  open,
+  sessionToken,
+  workflowId,
+  perkTitle,
+  onOpenChange,
+  onSettled,
+}: WorkflowPerkDialogProps) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [detail, setDetail] = useState<WorkflowDetailResult | null>(null);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const settledNotified = useRef(false);
+
+  const clearPoll = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const load = useCallback(
+    async (id: string) => {
+      const res = await getWorkflow(sessionToken, id);
+      if (!res.ok || !res.data) {
+        setError(res.error ?? "Failed to load application");
+        setLoading(false);
+        return;
+      }
+      setDetail({ workflow: res.data.workflow, steps: res.data.steps });
+      setError(null);
+      setLoading(false);
+      if (!AUTO_PROGRESS_STATES.includes(res.data.workflow.state)) {
+        clearPoll();
+      }
+    },
+    [sessionToken, clearPoll],
+  );
+
+  useEffect(() => {
+    if (!open || !workflowId) return;
+    settledNotified.current = false;
+    setLoading(true);
+    setDetail(null);
+    setAnswers({});
+    void load(workflowId);
+    return () => {
+      clearPoll();
+    };
+  }, [open, workflowId, load, clearPoll]);
+
+  useEffect(() => {
+    clearPoll();
+    if (
+      open &&
+      detail &&
+      AUTO_PROGRESS_STATES.includes(detail.workflow.state) &&
+      workflowId
+    ) {
+      pollRef.current = setInterval(() => {
+        void load(workflowId);
+      }, POLL_INTERVAL_MS);
+    }
+    return clearPoll;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, detail?.workflow.state, workflowId]);
+
+  useEffect(() => {
+    const keys = new Set(detail?.workflow.missingInputKeys ?? []);
+    for (const question of detail?.workflow.inputQuestions ?? []) {
+      keys.add(question.key);
+    }
+    if (keys.size > 0) {
+      setAnswers((current) => {
+        const next = { ...current };
+        for (const key of keys) {
+          if (!(key in next)) next[key] = "";
+        }
+        return next;
+      });
+    }
+  }, [detail?.workflow.missingInputKeys, detail?.workflow.inputQuestions]);
+
+  useEffect(() => {
+    if (!detail || settledNotified.current) return;
+    if (
+      detail.workflow.state === "COMPLETED" ||
+      detail.workflow.state === "FAILED" ||
+      detail.workflow.state === "CANCELLED"
+    ) {
+      settledNotified.current = true;
+      onSettled?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detail?.workflow.state]);
+
+  const visibleQuestionKeys = useMemo(() => {
+    if (!detail) return [];
+    const missing = detail.workflow.missingInputKeys;
+    const inputQuestions = detail.workflow.inputQuestions;
+    if (!inputQuestions?.length) return missing;
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const question of inputQuestions) {
+      if (
+        !seen.has(question.key) &&
+        (missing.includes(question.key) ||
+          isWorkflowQuestionVisible(question, answers))
+      ) {
+        seen.add(question.key);
+        ordered.push(question.key);
+      }
+    }
+    for (const key of missing) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        ordered.push(key);
+      }
+    }
+    return ordered;
+  }, [detail, answers]);
+
+  async function handleSubmitInputs() {
+    if (!detail) return;
+    const missing = detail.workflow.missingInputKeys;
+    const missingUnanswered = missing.filter(
+      (key) => !(answers[key] ?? "").trim(),
+    );
+    if (missingUnanswered.length > 0) {
+      setError("Please answer all questions above before continuing.");
+      return;
+    }
+    const sanitized = Object.fromEntries(
+      visibleQuestionKeys
+        .map((key) => [key, (answers[key] ?? "").trim()])
+        .filter(([, value]) => value.length > 0),
+    );
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await submitWorkflowInputs(
+        sessionToken,
+        detail.workflow.id,
+        sanitized,
+      );
+      if (!res.ok || !res.data) {
+        setError(res.error ?? "Failed to submit information");
+        return;
+      }
+      setDetail({ workflow: res.data.workflow, steps: res.data.steps });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleApprove() {
+    if (!detail?.workflow.currentStepKey) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await approveWorkflowStep(
+        sessionToken,
+        detail.workflow.id,
+        detail.workflow.currentStepKey,
+      );
+      if (!res.ok || !res.data) {
+        setError(res.error ?? "Failed to approve step");
+        return;
+      }
+      setDetail({ workflow: res.data.workflow, steps: res.data.steps });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleCancel() {
+    if (!detail) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await cancelWorkflow(sessionToken, detail.workflow.id);
+      if (!res.ok || !res.data) {
+        setError(res.error ?? "Failed to cancel application");
+        return;
+      }
+      trackPerksEvent("perk_workflow_cancelled", {
+        workflowId: detail.workflow.id,
+      });
+      toast({ title: "Application cancelled" });
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const workflow = detail?.workflow;
+  const badge = workflow ? stateBadge(workflow.state) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[min(90vh,760px)] max-w-lg overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{perkTitle}</DialogTitle>
+          <DialogDescription>
+            We&apos;ll only submit anything on your behalf after you
+            explicitly approve it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex items-center gap-2 py-8 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            Loading…
+          </div>
+        ) : !workflow ? (
+          <div className="space-y-3 py-4">
+            <p className="text-sm text-destructive">
+              {error ?? "Could not load this application."}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              {badge && <Badge variant={badge.variant}>{badge.label}</Badge>}
+            </div>
+
+            <div className="space-y-1.5">
+              <Progress value={workflow.completionPercent} />
+              <p className="text-xs text-muted-foreground">
+                {workflow.completionPercent}% complete
+              </p>
+            </div>
+
+            {detail && detail.steps.length > 0 ? (
+              <ul className="space-y-2">
+                {detail.steps.map((step) => (
+                  <li
+                    key={step.stepKey}
+                    className="flex items-center gap-2 text-sm"
+                  >
+                    {stepIcon(step)}
+                    <span
+                      className={
+                        step.status === "COMPLETED"
+                          ? "text-muted-foreground line-through"
+                          : ""
+                      }
+                    >
+                      {humanize(step.stepKey)}
+                    </span>
+                    {step.requiresApproval && step.status !== "COMPLETED" && (
+                      <Badge variant="outline" className="text-[10px]">
+                        Needs approval
+                      </Badge>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            {workflow.state === "WAITING_FOR_INPUT" && (
+              <div className="space-y-4 rounded-md bg-muted/40 p-3">
+                <p className="text-sm font-medium">
+                  We need a bit more information to continue.
+                </p>
+                {visibleQuestionKeys.map((key) => {
+                  const question = workflow.inputQuestions?.find(
+                    (q) => q.key === key,
+                  );
+                  if (!question) return null;
+                  return (
+                    <WorkflowQuestionField
+                      key={key}
+                      question={question}
+                      value={answers[key] ?? ""}
+                      onChange={(value) =>
+                        setAnswers((current) => ({ ...current, [key]: value }))
+                      }
+                      disabled={submitting}
+                      idPrefix="perk-workflow"
+                    />
+                  );
+                })}
+                <Button
+                  size="sm"
+                  onClick={() => void handleSubmitInputs()}
+                  disabled={submitting}
+                >
+                  {submitting ? (
+                    <>
+                      <Loader2
+                        className="mr-2 h-4 w-4 animate-spin"
+                        aria-hidden
+                      />
+                      Submitting…
+                    </>
+                  ) : (
+                    "Continue"
+                  )}
+                </Button>
+              </div>
+            )}
+
+            {workflow.state === "WAITING_FOR_APPROVAL" && (
+              <div className="space-y-3 rounded-md bg-muted/40 p-3">
+                <p className="text-sm font-medium">
+                  Your approval is needed for &quot;
+                  {humanize(workflow.currentStepKey ?? "")}&quot; before we
+                  continue. Nothing is submitted without your say-so.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    onClick={() => void handleApprove()}
+                    disabled={submitting}
+                  >
+                    {submitting ? (
+                      <Loader2
+                        className="mr-2 h-4 w-4 animate-spin"
+                        aria-hidden
+                      />
+                    ) : null}
+                    Approve
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void handleCancel()}
+                    disabled={submitting}
+                  >
+                    Cancel application
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {(workflow.state === "CREATED" ||
+              workflow.state === "READY_TO_EXECUTE" ||
+              workflow.state === "EXECUTING") && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Working on it — this updates automatically.
+              </div>
+            )}
+
+            {workflow.state === "COMPLETED" && (
+              <div className="space-y-2 rounded-md bg-primary/10 p-3">
+                <p className="text-sm font-medium text-primary">
+                  Application completed successfully.
+                </p>
+              </div>
+            )}
+
+            {workflow.state === "FAILED" && (
+              <div className="space-y-2 rounded-md bg-destructive/10 p-3">
+                <p className="text-sm font-medium text-destructive">
+                  This application failed
+                  {workflow.failureReason
+                    ? `: ${workflow.failureReason}`
+                    : "."}
+                </p>
+              </div>
+            )}
+
+            {workflow.state === "CANCELLED" && (
+              <p className="text-sm text-muted-foreground">
+                This application was cancelled.
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          {workflow && CANCELLABLE_STATES.includes(workflow.state) ? (
+            <Button
+              variant="ghost"
+              className="text-muted-foreground"
+              onClick={() => void handleCancel()}
+              disabled={submitting}
+            >
+              Cancel application
+            </Button>
+          ) : (
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Close
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/WorkflowQuestionFields.tsx
+++ b/src/components/WorkflowQuestionFields.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -15,8 +15,44 @@ export function isWorkflowQuestionVisible(
 ): boolean {
   if (!question.showWhen) return true;
   const parentAnswer = answers[question.showWhen.questionKey];
-  if (parentAnswer === undefined) return false;
-  return question.showWhen.values.includes(parentAnswer);
+  if (parentAnswer === undefined || parentAnswer.trim() === "") return false;
+  const parentTokens = parentAnswer
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+  return question.showWhen.values.some((value) =>
+    parentTokens.includes(value),
+  );
+}
+
+/** Ordered keys to render while WAITING_FOR_INPUT — includes missing keys even
+ * without rich question metadata so users can always answer required fields. */
+export function getVisibleWorkflowQuestionKeys(params: {
+  missingInputKeys: string[];
+  inputQuestions?: WorkflowQuestionDefinition[];
+  answers: Record<string, string>;
+}): string[] {
+  const { missingInputKeys, inputQuestions, answers } = params;
+  if (!inputQuestions?.length) return missingInputKeys;
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const question of inputQuestions) {
+    if (
+      !seen.has(question.key) &&
+      (missingInputKeys.includes(question.key) ||
+        isWorkflowQuestionVisible(question, answers))
+    ) {
+      seen.add(question.key);
+      ordered.push(question.key);
+    }
+  }
+  for (const key of missingInputKeys) {
+    if (!seen.has(key)) {
+      seen.add(key);
+      ordered.push(key);
+    }
+  }
+  return ordered;
 }
 
 function parseMultiSelectValue(
@@ -69,6 +105,17 @@ export function WorkflowQuestionField({
   const [singleOtherSelected, setSingleOtherSelected] = useState(
     () => question.allowOther && value.length > 0 && !isKnownSingleValue,
   );
+
+  useEffect(() => {
+    const opts = question.options ?? [];
+    if (!question.allowOther) {
+      setSingleOtherSelected(false);
+      return;
+    }
+    setSingleOtherSelected(
+      value.length > 0 && !opts.some((option) => option.value === value),
+    );
+  }, [question.allowOther, question.options, value]);
 
   return (
     <div className="space-y-2">

--- a/src/components/WorkflowQuestionFields.tsx
+++ b/src/components/WorkflowQuestionFields.tsx
@@ -1,0 +1,205 @@
+import { useState } from "react";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { WorkflowQuestionDefinition } from "@/auth/backend";
+
+const OTHER_RADIO_VALUE = "__other__";
+
+/** Answers are always plain strings (see backend WorkflowVaultPort contract) —
+ * multi-select selections are stored as a single comma-joined string. */
+export function isWorkflowQuestionVisible(
+  question: WorkflowQuestionDefinition,
+  answers: Record<string, string>,
+): boolean {
+  if (!question.showWhen) return true;
+  const parentAnswer = answers[question.showWhen.questionKey];
+  if (parentAnswer === undefined) return false;
+  return question.showWhen.values.includes(parentAnswer);
+}
+
+function parseMultiSelectValue(
+  value: string,
+  options: NonNullable<WorkflowQuestionDefinition["options"]>,
+): { selected: Set<string>; other: string } {
+  const optionValues = new Set(options.map((o) => o.value));
+  const tokens = value
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const selected = new Set(tokens.filter((t) => optionValues.has(t)));
+  const other = tokens.filter((t) => !optionValues.has(t)).join(", ");
+  return { selected, other };
+}
+
+function buildMultiSelectValue(
+  selected: Set<string>,
+  options: NonNullable<WorkflowQuestionDefinition["options"]>,
+  other: string,
+): string {
+  const ordered = options
+    .filter((o) => selected.has(o.value))
+    .map((o) => o.value);
+  const trimmedOther = other.trim();
+  return [...ordered, ...(trimmedOther ? [trimmedOther] : [])].join(", ");
+}
+
+interface WorkflowQuestionFieldProps {
+  question: WorkflowQuestionDefinition;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  idPrefix?: string;
+}
+
+/** Renders a single workflow question field (email/text/single_select/multi_select,
+ * with optional "Other" free text) — shared between WorkflowsCard and the Perks-page
+ * workflow dialog so every client renders the same intake form from one definition. */
+export function WorkflowQuestionField({
+  question,
+  value,
+  onChange,
+  disabled,
+  idPrefix,
+}: WorkflowQuestionFieldProps) {
+  const fieldId = `${idPrefix ?? "wq"}-${question.key}`;
+  const options = question.options ?? [];
+  const isKnownSingleValue = options.some((o) => o.value === value);
+  const [singleOtherSelected, setSingleOtherSelected] = useState(
+    () => question.allowOther && value.length > 0 && !isKnownSingleValue,
+  );
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={fieldId}>{question.label}</Label>
+      {question.helpText ? (
+        <p className="text-xs text-muted-foreground">{question.helpText}</p>
+      ) : null}
+
+      {question.type === "email" || question.type === "text" ? (
+        <Input
+          id={fieldId}
+          type={question.type === "email" ? "email" : "text"}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+        />
+      ) : null}
+
+      {question.type === "single_select" ? (
+        <RadioGroup
+          value={
+            singleOtherSelected
+              ? OTHER_RADIO_VALUE
+              : isKnownSingleValue
+                ? value
+                : ""
+          }
+          onValueChange={(next) => {
+            if (next === OTHER_RADIO_VALUE) {
+              setSingleOtherSelected(true);
+              onChange("");
+              return;
+            }
+            setSingleOtherSelected(false);
+            onChange(next);
+          }}
+          className="space-y-1.5"
+        >
+          {options.map((option) => (
+            <div key={option.value} className="flex items-center gap-2">
+              <RadioGroupItem
+                value={option.value}
+                id={`${fieldId}-${option.value}`}
+                disabled={disabled}
+              />
+              <Label
+                htmlFor={`${fieldId}-${option.value}`}
+                className="font-normal"
+              >
+                {option.label}
+              </Label>
+            </div>
+          ))}
+          {question.allowOther ? (
+            <div className="flex items-center gap-2">
+              <RadioGroupItem
+                value={OTHER_RADIO_VALUE}
+                id={`${fieldId}-other`}
+                disabled={disabled}
+              />
+              <Label htmlFor={`${fieldId}-other`} className="font-normal">
+                Other
+              </Label>
+            </div>
+          ) : null}
+          {singleOtherSelected ? (
+            <Input
+              value={value}
+              onChange={(e) => onChange(e.target.value)}
+              placeholder="Please specify"
+              disabled={disabled}
+              className="mt-1"
+            />
+          ) : null}
+        </RadioGroup>
+      ) : null}
+
+      {question.type === "multi_select"
+        ? (() => {
+            const { selected, other } = parseMultiSelectValue(value, options);
+            return (
+              <div className="space-y-1.5">
+                {options.map((option) => (
+                  <div key={option.value} className="flex items-center gap-2">
+                    <Checkbox
+                      id={`${fieldId}-${option.value}`}
+                      checked={selected.has(option.value)}
+                      disabled={disabled}
+                      onCheckedChange={(checked) => {
+                        const next = new Set(selected);
+                        if (checked) next.add(option.value);
+                        else next.delete(option.value);
+                        onChange(buildMultiSelectValue(next, options, other));
+                      }}
+                    />
+                    <Label
+                      htmlFor={`${fieldId}-${option.value}`}
+                      className="font-normal"
+                    >
+                      {option.label}
+                    </Label>
+                  </div>
+                ))}
+                {question.allowOther ? (
+                  <div className="flex items-center gap-2 pt-1">
+                    <Label
+                      htmlFor={`${fieldId}-other`}
+                      className="whitespace-nowrap text-sm font-normal text-muted-foreground"
+                    >
+                      Other:
+                    </Label>
+                    <Input
+                      id={`${fieldId}-other`}
+                      value={other}
+                      onChange={(e) =>
+                        onChange(
+                          buildMultiSelectValue(
+                            selected,
+                            options,
+                            e.target.value,
+                          ),
+                        )
+                      }
+                      disabled={disabled}
+                    />
+                  </div>
+                ) : null}
+              </div>
+            );
+          })()
+        : null}
+    </div>
+  );
+}

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Card,
   CardContent,
@@ -16,6 +17,7 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
+  Gift,
   Loader2,
   Sparkles,
   XCircle,
@@ -23,7 +25,6 @@ import {
 import {
   approveWorkflowStep,
   cancelWorkflow,
-  createWorkflow,
   getWorkflow,
   listWorkflows,
   submitWorkflowInputs,
@@ -33,13 +34,14 @@ import {
   type WorkflowSummary,
 } from "@/auth/backend";
 import { getUserProfileInformation, type ProfileQuestion } from "@/auth";
+import {
+  isWorkflowQuestionVisible,
+  WorkflowQuestionField,
+} from "@/components/WorkflowQuestionFields";
 
 interface WorkflowsCardProps {
   sessionToken: string;
 }
-
-/** The one workflow type available to users in this phase — see backend workflow-types/index.ts. */
-const DEMO_WORKFLOW_TYPE = "demo_partner_signup";
 
 const ACTIVE_STATES: WorkflowState[] = [
   "CREATED",
@@ -129,7 +131,6 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
   const [active, setActive] = useState<WorkflowDetailResult | null>(null);
   const [questions, setQuestions] = useState<ProfileQuestion[]>([]);
   const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [starting, setStarting] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -215,16 +216,20 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
   }, [active?.workflow.id, active?.workflow.state]);
 
   useEffect(() => {
-    if (active?.workflow.missingInputKeys?.length) {
+    const keys = new Set(active?.workflow.missingInputKeys ?? []);
+    for (const question of active?.workflow.inputQuestions ?? []) {
+      keys.add(question.key);
+    }
+    if (keys.size > 0) {
       setAnswers((current) => {
         const next = { ...current };
-        for (const key of active.workflow.missingInputKeys) {
+        for (const key of keys) {
           if (!(key in next)) next[key] = "";
         }
         return next;
       });
     }
-  }, [active?.workflow.missingInputKeys]);
+  }, [active?.workflow.missingInputKeys, active?.workflow.inputQuestions]);
 
   const questionByKey = useMemo(() => {
     const map = new Map<string, ProfileQuestion>();
@@ -232,37 +237,51 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
     return map;
   }, [questions]);
 
-  async function handleStart() {
-    setStarting(true);
-    setError(null);
-    try {
-      const res = await createWorkflow(sessionToken, DEMO_WORKFLOW_TYPE);
-      if (!res.ok || !res.data) {
-        setError(res.error ?? "Failed to start workflow");
-        return;
+  /** Fields to render while WAITING_FOR_INPUT: every required-and-missing key, plus any
+   * optional questions (e.g. Chase's direct-deposit follow-ups) currently visible per
+   * their showWhen condition — otherwise those answers would have nowhere to be entered. */
+  const visibleQuestionKeys = useMemo(() => {
+    if (!active) return [];
+    const missing = active.workflow.missingInputKeys;
+    const inputQuestions = active.workflow.inputQuestions;
+    if (!inputQuestions?.length) return missing;
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const question of inputQuestions) {
+      if (
+        !seen.has(question.key) &&
+        (missing.includes(question.key) ||
+          isWorkflowQuestionVisible(question, answers))
+      ) {
+        seen.add(question.key);
+        ordered.push(question.key);
       }
-      if (active && !ACTIVE_STATES.includes(active.workflow.state)) {
-        setHistory((current) => [active.workflow, ...current]);
-      }
-      setActive({ workflow: res.data.workflow, steps: res.data.steps });
-      setAnswers({});
-    } finally {
-      setStarting(false);
     }
-  }
+    // Keep any missing keys without question metadata at the end as a fallback.
+    for (const key of missing) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        ordered.push(key);
+      }
+    }
+    return ordered;
+  }, [active, answers]);
 
   async function handleSubmitInputs() {
     if (!active) return;
     const missing = active.workflow.missingInputKeys;
-    const sanitized = Object.fromEntries(
-      missing
-        .map((key) => [key, (answers[key] ?? "").trim()])
-        .filter(([, value]) => value.length > 0),
+    const missingUnanswered = missing.filter(
+      (key) => !(answers[key] ?? "").trim(),
     );
-    if (Object.keys(sanitized).length < missing.length) {
+    if (missingUnanswered.length > 0) {
       setError("Please answer all questions above before continuing.");
       return;
     }
+    const sanitized = Object.fromEntries(
+      visibleQuestionKeys
+        .map((key) => [key, (answers[key] ?? "").trim()])
+        .filter(([, value]) => value.length > 0),
+    );
     setSubmitting(true);
     setError(null);
     try {
@@ -355,18 +374,14 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
         {!active ? (
           <div className="rounded-md border border-dashed p-4 text-center space-y-3">
             <p className="text-sm text-muted-foreground">
-              No application in progress. Try our demo partner application to
-              see how KeenVPN can complete applications for you.
+              No application in progress. Explore Perks to let KeenVPN
+              auto-apply to partner offers on your behalf.
             </p>
-            <Button onClick={() => void handleStart()} disabled={starting}>
-              {starting ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-                  Starting…
-                </>
-              ) : (
-                "Start demo application"
-              )}
+            <Button asChild>
+              <Link to="/perks">
+                <Gift className="mr-2 h-4 w-4" aria-hidden />
+                Explore Perks
+              </Link>
             </Button>
           </div>
         ) : (
@@ -417,7 +432,24 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
                 <p className="text-sm font-medium">
                   We need a bit more information to continue.
                 </p>
-                {active.workflow.missingInputKeys.map((key) => {
+                {visibleQuestionKeys.map((key) => {
+                  const richQuestion = active.workflow.inputQuestions?.find(
+                    (q) => q.key === key,
+                  );
+                  if (richQuestion) {
+                    return (
+                      <WorkflowQuestionField
+                        key={key}
+                        question={richQuestion}
+                        value={answers[key] ?? ""}
+                        onChange={(value) =>
+                          setAnswers((current) => ({ ...current, [key]: value }))
+                        }
+                        disabled={submitting}
+                        idPrefix="workflows-card"
+                      />
+                    );
+                  }
                   const question = questionByKey.get(key);
                   return (
                     <div key={key} className="space-y-2">
@@ -512,8 +544,8 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
                 <p className="text-sm font-medium text-primary">
                   Application completed successfully.
                 </p>
-                <Button size="sm" variant="outline" onClick={() => void handleStart()} disabled={starting}>
-                  Start another
+                <Button size="sm" variant="outline" asChild>
+                  <Link to="/perks">Explore more perks</Link>
                 </Button>
               </div>
             )}
@@ -524,8 +556,8 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
                   This application failed
                   {active.workflow.failureReason ? `: ${active.workflow.failureReason}` : "."}
                 </p>
-                <Button size="sm" variant="outline" onClick={() => void handleStart()} disabled={starting}>
-                  Try again
+                <Button size="sm" variant="outline" asChild>
+                  <Link to="/perks">View perks</Link>
                 </Button>
               </div>
             )}

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -35,25 +35,18 @@ import {
 } from "@/auth/backend";
 import { getUserProfileInformation, type ProfileQuestion } from "@/auth";
 import {
-  isWorkflowQuestionVisible,
   WorkflowQuestionField,
+  getVisibleWorkflowQuestionKeys,
 } from "@/components/WorkflowQuestionFields";
-import { selectPrimaryActiveWorkflow } from "@/lib/workflow-ui";
+import {
+  ACTIVE_WORKFLOW_STATES,
+  selectPrimaryActiveWorkflow,
+} from "@/lib/workflow-ui";
 
 interface WorkflowsCardProps {
   sessionToken: string;
 }
 
-const ACTIVE_STATES: WorkflowState[] = [
-  "CREATED",
-  "WAITING_FOR_INPUT",
-  "READY_TO_EXECUTE",
-  "EXECUTING",
-  "WAITING_FOR_APPROVAL",
-];
-
-/** States that progress on their own (via cron/engine) and are worth polling for updates.
- * WAITING_FOR_INPUT / WAITING_FOR_APPROVAL only change once the user acts, so no need to poll those. */
 const AUTO_PROGRESS_STATES: WorkflowState[] = [
   "CREATED",
   "READY_TO_EXECUTE",
@@ -152,7 +145,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
         return;
       }
       setActive({ workflow: res.data.workflow, steps: res.data.steps });
-      if (!ACTIVE_STATES.includes(res.data.workflow.state)) {
+      if (!AUTO_PROGRESS_STATES.includes(res.data.workflow.state)) {
         clearPoll();
       }
     },
@@ -243,29 +236,11 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
    * their showWhen condition — otherwise those answers would have nowhere to be entered. */
   const visibleQuestionKeys = useMemo(() => {
     if (!active) return [];
-    const missing = active.workflow.missingInputKeys;
-    const inputQuestions = active.workflow.inputQuestions;
-    if (!inputQuestions?.length) return missing;
-    const seen = new Set<string>();
-    const ordered: string[] = [];
-    for (const question of inputQuestions) {
-      if (
-        !seen.has(question.key) &&
-        (missing.includes(question.key) ||
-          isWorkflowQuestionVisible(question, answers))
-      ) {
-        seen.add(question.key);
-        ordered.push(question.key);
-      }
-    }
-    // Keep any missing keys without question metadata at the end as a fallback.
-    for (const key of missing) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        ordered.push(key);
-      }
-    }
-    return ordered;
+    return getVisibleWorkflowQuestionKeys({
+      missingInputKeys: active.workflow.missingInputKeys,
+      inputQuestions: active.workflow.inputQuestions,
+      answers,
+    });
   }, [active, answers]);
 
   async function handleSubmitInputs() {

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -38,6 +38,7 @@ import {
   isWorkflowQuestionVisible,
   WorkflowQuestionField,
 } from "@/components/WorkflowQuestionFields";
+import { selectPrimaryActiveWorkflow } from "@/lib/workflow-ui";
 
 interface WorkflowsCardProps {
   sessionToken: string;
@@ -185,7 +186,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
     }
 
     const workflows = listRes.data.workflows;
-    const activeSummary = workflows.find((w) => ACTIVE_STATES.includes(w.state));
+    const activeSummary = selectPrimaryActiveWorkflow(workflows);
     setHistory(workflows.filter((w) => w !== activeSummary));
 
     if (activeSummary) {

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -4,6 +4,23 @@ export const MIN_BUSINESS_SEATS = 2;
 export const DEFAULT_BUSINESS_SEATS = 5;
 export const MAX_BUSINESS_SEATS = 25;
 
+export function resolvePlanMinSeats(plan?: {
+  minSeats?: number;
+} | null): number {
+  return plan?.minSeats ?? MIN_BUSINESS_SEATS;
+}
+
+export function resolvePlanDefaultSeats(plan?: {
+  minSeats?: number;
+  defaultSeats?: number;
+} | null): number {
+  const minSeats = resolvePlanMinSeats(plan);
+  return Math.max(
+    minSeats,
+    Math.min(MAX_BUSINESS_SEATS, plan?.defaultSeats ?? DEFAULT_BUSINESS_SEATS),
+  );
+}
+
 export const enterprisePlan: PricingPlan = {
   name: "Enterprise",
   description: "Custom solutions for large organizations (50+ users)",

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -2,6 +2,7 @@ import type { PricingPlan } from "@/lib/pricing";
 
 export const MIN_BUSINESS_SEATS = 2;
 export const DEFAULT_BUSINESS_SEATS = 5;
+export const MAX_BUSINESS_SEATS = 25;
 
 export const enterprisePlan: PricingPlan = {
   name: "Enterprise",

--- a/src/constants/pricing.ts
+++ b/src/constants/pricing.ts
@@ -1,5 +1,8 @@
 import type { PricingPlan } from "@/lib/pricing";
 
+export const MIN_BUSINESS_SEATS = 2;
+export const DEFAULT_BUSINESS_SEATS = 5;
+
 export const enterprisePlan: PricingPlan = {
   name: "Enterprise",
   description: "Custom solutions for large organizations (50+ users)",
@@ -42,7 +45,12 @@ export const faqs = [
   {
     question: "How does billing work for annual plans?",
     answer:
-      "Annual plans are billed once per year upfront. You'll save significantly compared to monthly billing - that's equivalent to getting 2 months free on Individual plans and 2.5 months free on Team plans.",
+      "Annual plans are billed once per year upfront. You'll save significantly compared to monthly billing — that's equivalent to getting 2 months free on Individual plans.",
+  },
+  {
+    question: "How does Business seat billing work?",
+    answer:
+      "Business is priced per seat. Choose how many seats you need (minimum 2), invite teammates by email, and each seat includes 5 connected devices. You can buy or reduce seats anytime from your account dashboard.",
   },
   {
     question: "Do you keep logs of my activity?",
@@ -84,87 +92,75 @@ export const allFeatures = [
 export interface FeatureComparisonRow {
   feature: string;
   individual: string | boolean;
-  family: string | boolean;
-  team: string | boolean;
+  business: string | boolean;
   enterprise: string | boolean;
 }
 
 export const featureComparison: FeatureComparisonRow[] = [
   {
     feature: "Simultaneous device connections",
-    individual: "Up to 10",
-    family: "Up to 12",
-    team: "Up to 14",
+    individual: "Up to 3",
+    business: "5 per seat",
     enterprise: "Custom",
   },
   {
     feature: "Bandwidth",
     individual: "Unlimited",
-    family: "Unlimited",
-    team: "Unlimited",
+    business: "Unlimited",
     enterprise: "Unlimited",
   },
   {
     feature: "Military-grade encryption",
     individual: true,
-    family: true,
-    team: true,
+    business: true,
     enterprise: true,
   },
   {
     feature: "No-log policy",
     individual: true,
-    family: true,
-    team: true,
+    business: true,
     enterprise: true,
   },
   {
     feature: "Kill switch protection",
     individual: true,
-    family: true,
-    team: true,
+    business: true,
     enterprise: true,
   },
   {
     feature: "24/7 customer support",
     individual: true,
-    family: true,
-    team: true,
+    business: true,
     enterprise: true,
   },
   {
     feature: "Free trial duration",
     individual: "1 month",
-    family: "1 month",
-    team: "1 month",
+    business: "1 month",
     enterprise: "1 month",
   },
   {
     feature: "Team management dashboard",
     individual: false,
-    family: false,
-    team: true,
+    business: true,
     enterprise: true,
   },
   {
     feature: "Priority support",
     individual: false,
-    family: false,
-    team: true,
+    business: true,
     enterprise: true,
   },
   {
     feature: "Custom security solutions",
     individual: false,
-    family: false,
-    team: false,
+    business: false,
     enterprise: true,
   },
   {
     feature: "Dedicated account manager",
     individual: false,
-    family: false,
-    team: false,
+    business: false,
     enterprise: true,
   },
 ];
@@ -175,11 +171,9 @@ export function featureComparisonValueForPlan(
   row: FeatureComparisonRow,
 ): string | boolean {
   switch (planName) {
-    case "Family":
-      return row.family;
     case "Business":
     case "Team":
-      return row.team;
+      return row.business;
     case "Enterprise":
       return row.enterprise;
     default:

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -59,6 +59,13 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
   const plansByType = apiPlans.reduce(
     (acc, plan) => {
       const id = plan.id.toLowerCase();
+      const isLegacyFamilyOnly =
+        id.includes("family") &&
+        !id.includes("family_plus") &&
+        !id.includes("familyplus");
+      if (isLegacyFamilyOnly) {
+        return acc;
+      }
       // Family is retired from the purchasable catalog; any legacy family_plus/familyplus
       // price ids the backend might still return are folded into Business (seat-based).
       const isTeam =
@@ -157,7 +164,10 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
         ? (monthly?.minSeats ?? annual?.minSeats ?? 2)
         : undefined,
       defaultSeats: isTeam
-        ? (monthly?.defaultSeats ?? annual?.defaultSeats ?? 5)
+        ? Math.max(
+            monthly?.minSeats ?? annual?.minSeats ?? 2,
+            monthly?.defaultSeats ?? annual?.defaultSeats ?? 5,
+          )
         : undefined,
       monthlyPriceId: monthly?.priceId,
       annualPriceId: annual?.priceId,

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -12,6 +12,10 @@ export interface ApiPlan {
   }[];
   priceId: string;
   description?: string;
+  /** True for the Business plan: `price` is per-seat and checkout takes a seat quantity. */
+  isPerSeat?: boolean;
+  minSeats?: number;
+  defaultSeats?: number;
 }
 
 import {
@@ -43,6 +47,10 @@ export interface PricingPlan {
   }[];
   buttonText: string;
   popular: boolean;
+  /** True for the Business plan: price is per-seat and checkout takes a seat quantity. */
+  isPerSeat?: boolean;
+  minSeats?: number;
+  defaultSeats?: number;
   monthlyPriceId?: string;
   annualPriceId?: string;
 }
@@ -51,27 +59,15 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
   const plansByType = apiPlans.reduce(
     (acc, plan) => {
       const id = plan.id.toLowerCase();
-      const isFamily =
-        id.includes("family") &&
-        !id.includes("family_plus") &&
-        !id.includes("familyplus");
+      // Family is retired from the purchasable catalog; any legacy family_plus/familyplus
+      // price ids the backend might still return are folded into Business (seat-based).
       const isTeam =
         id.includes("team") ||
         id.includes("business") ||
         id.includes("family_plus") ||
         id.includes("familyplus");
-      const isPremium =
-        id.includes("premium") &&
-        !id.includes("family") &&
-        !id.includes("team") &&
-        !id.includes("business");
-      const key = isPremium
-        ? "premium"
-        : isFamily
-          ? "family"
-          : isTeam
-            ? "team"
-            : "other";
+      const isPremium = id.includes("premium") && !isTeam;
+      const key = isPremium ? "premium" : isTeam ? "team" : "other";
 
       if (!acc[key]) {
         acc[key] = { monthly: null, annual: null };
@@ -94,7 +90,6 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
     if (!monthly && !annual) return;
 
     const isPremium = type === "premium";
-    const isFamily = type === "family";
     const isTeam = type === "team";
     const monthlyPrice = monthly?.price || annual?.price || 0;
     const annualPrice =
@@ -123,38 +118,29 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
         ? monthly.features
         : [];
 
+    // Business bills per seat: `monthlyPrice`/`annualPrice` here is the per-seat price.
     const deviceConnectionFeature = {
       name: isTeam
-        ? "Up to 14 simultaneous devices"
-        : isFamily
-          ? "Up to 12 simultaneous devices"
-          : "Up to 10 simultaneous devices",
+        ? "5 connected devices per seat"
+        : "Up to 3 connected devices",
       included: true,
       highlighted: true,
     };
 
     const mergedFeatures = [
       deviceConnectionFeature,
-      ...features.filter((f) => !/simultaneous device/i.test(f.name)),
+      ...features.filter((f) => !/simultaneous device|connected device/i.test(f.name)),
     ];
 
     transformedPlans.push({
       monthlyId: monthly?.id,
       annualId: annual?.id,
-        name: isPremium
-        ? "Individual"
-        : isFamily
-          ? "Family"
-          : isTeam
-            ? "Business"
-            : "Premium",
+      name: isPremium ? "Individual" : isTeam ? "Business" : "Premium",
       description: isPremium
         ? "Perfect for personal use"
-        : isFamily
-          ? "Share premium with up to 5 members"
-          : isTeam
-            ? "For teams and businesses (up to 10 members)"
-            : "Premium VPN service",
+        : isTeam
+          ? "Buy seats for your whole team — pay per person"
+          : "Premium VPN service",
       monthlyPrice,
       annualPrice,
       monthlyPriceDisplay: `$${monthlyPrice}`,
@@ -165,7 +151,14 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
       annualSavingsLabel,
       features: mergedFeatures,
       buttonText: "Start Free Trial",
-      popular: isFamily,
+      popular: isTeam,
+      isPerSeat: isTeam,
+      minSeats: isTeam
+        ? (monthly?.minSeats ?? annual?.minSeats ?? 2)
+        : undefined,
+      defaultSeats: isTeam
+        ? (monthly?.defaultSeats ?? annual?.defaultSeats ?? 5)
+        : undefined,
       monthlyPriceId: monthly?.priceId,
       annualPriceId: annual?.priceId,
     });
@@ -175,9 +168,8 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
     const order: Record<string, number> = {
       Individual: 0,
       Premium: 0,
-      Family: 1,
-      Business: 2,
-      Team: 2,
+      Business: 1,
+      Team: 1,
     };
     return (
       (order[a.name as keyof typeof order] ?? 99) -

--- a/src/lib/product-analytics.ts
+++ b/src/lib/product-analytics.ts
@@ -75,7 +75,8 @@ export type PerkAnalyticsEventName =
   | "perk_restored_to_new"
   | "perk_marked_not_interested"
   | "perk_moved_from_snoozed_to_not_interested"
-  | "perk_moved_from_not_interested_to_snoozed";
+  | "perk_moved_from_not_interested_to_snoozed"
+  | "perk_workflow_cancelled";
 
 export function trackPerksEvent(
   eventName: PerkAnalyticsEventName,

--- a/src/lib/subscription-cta.test.ts
+++ b/src/lib/subscription-cta.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import type { SubscriptionData } from "@/auth/types";
 import {
   canUpgradeStripeToBusinessPlan,
-  canUpgradeStripeToFamilyPlan,
   resolveMembershipPlanTier,
 } from "@/lib/subscription-cta";
 
@@ -44,19 +43,23 @@ describe("membership plan tier helpers", () => {
     ).toBe("business");
   });
 
-  it("detects stripe upgrade eligibility", () => {
+  it("detects stripe upgrade eligibility to Business (Family retired from catalog)", () => {
     const individual = stripeSub({
       plan: "Premium VPN - Monthly",
       planId: "premium_monthly",
     });
+    // Grandfathered legacy Family subscribers can still upgrade to Business.
     const family = stripeSub({
       plan: "KeenVPN Family - Monthly",
       planId: "family_monthly",
     });
+    const business = stripeSub({
+      plan: "KeenVPN Business - Monthly",
+      planId: "team_monthly",
+    });
 
-    expect(canUpgradeStripeToFamilyPlan(individual)).toBe(true);
-    expect(canUpgradeStripeToBusinessPlan(individual)).toBe(false);
-    expect(canUpgradeStripeToFamilyPlan(family)).toBe(false);
+    expect(canUpgradeStripeToBusinessPlan(individual)).toBe(true);
     expect(canUpgradeStripeToBusinessPlan(family)).toBe(true);
+    expect(canUpgradeStripeToBusinessPlan(business)).toBe(false);
   });
 });

--- a/src/lib/subscription-cta.ts
+++ b/src/lib/subscription-cta.ts
@@ -203,31 +203,22 @@ function isEligibleStripePlanManager(
   return status === "active" || status === "trialing";
 }
 
-/** Stripe owner on Individual — can upgrade to Family or Business via billing portal. */
-export function canUpgradeStripeToFamilyPlan(
-  subscription: SubscriptionData | null | undefined,
-): boolean {
-  return (
-    isEligibleStripePlanManager(subscription) &&
-    resolveMembershipPlanTier(subscription) === "individual"
-  );
-}
-
-/** Stripe owner on Family — can upgrade to Business via billing portal. */
+/**
+ * Stripe owner not already on Business — can upgrade to Business (seat-based, Slack/Devin-style)
+ * via the billing portal. Covers both current Individual subscribers and legacy/grandfathered
+ * Family subscribers, since Family is retired from the purchasable catalog.
+ */
 export function canUpgradeStripeToBusinessPlan(
   subscription: SubscriptionData | null | undefined,
 ): boolean {
   return (
     isEligibleStripePlanManager(subscription) &&
-    resolveMembershipPlanTier(subscription) === "family"
+    resolveMembershipPlanTier(subscription) !== "business"
   );
 }
 
 export function canUpgradeStripeMembershipPlan(
   subscription: SubscriptionData | null | undefined,
 ): boolean {
-  return (
-    canUpgradeStripeToFamilyPlan(subscription) ||
-    canUpgradeStripeToBusinessPlan(subscription)
-  );
+  return canUpgradeStripeToBusinessPlan(subscription);
 }

--- a/src/lib/workflow-ui.ts
+++ b/src/lib/workflow-ui.ts
@@ -4,7 +4,8 @@ import type {
   WorkflowSummary,
 } from "@/auth/backend";
 
-const ACTIVE_STATES: WorkflowState[] = [
+/** Non-terminal workflow states — shared by Applications card and Perks selection. */
+export const ACTIVE_WORKFLOW_STATES: WorkflowState[] = [
   "CREATED",
   "WAITING_FOR_INPUT",
   "READY_TO_EXECUTE",
@@ -25,7 +26,7 @@ export function selectPrimaryActiveWorkflow(
   workflows: WorkflowSummary[],
 ): WorkflowSummary | undefined {
   const active = workflows.filter((workflow) =>
-    ACTIVE_STATES.includes(workflow.state),
+    ACTIVE_WORKFLOW_STATES.includes(workflow.state),
   );
   if (active.length === 0) return undefined;
 
@@ -49,4 +50,22 @@ export function pendingApprovalFromWorkflows(
     workflowId: waiting.id,
     stepKey: waiting.currentStepKey,
   };
+}
+
+export function getWorkflowVisibleQuestionKeys(
+  detail: Pick<WorkflowDetailResult, "workflow">,
+  answers: Record<string, string>,
+): string[] {
+  return getVisibleWorkflowQuestionKeys({
+    missingInputKeys: detail.workflow.missingInputKeys,
+    inputQuestions: detail.workflow.inputQuestions,
+    answers,
+  });
+}
+
+export function humanizeWorkflowKey(key: string): string {
+  return key
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }

--- a/src/lib/workflow-ui.ts
+++ b/src/lib/workflow-ui.ts
@@ -1,0 +1,52 @@
+import type {
+  AiPendingApproval,
+  WorkflowState,
+  WorkflowSummary,
+} from "@/auth/backend";
+
+const ACTIVE_STATES: WorkflowState[] = [
+  "CREATED",
+  "WAITING_FOR_INPUT",
+  "READY_TO_EXECUTE",
+  "EXECUTING",
+  "WAITING_FOR_APPROVAL",
+];
+
+const ACTIVE_STATE_PRIORITY: Partial<Record<WorkflowState, number>> = {
+  WAITING_FOR_APPROVAL: 0,
+  WAITING_FOR_INPUT: 1,
+  EXECUTING: 2,
+  READY_TO_EXECUTE: 3,
+  CREATED: 4,
+};
+
+/** Prefer workflows that need user action, then the most recently updated run. */
+export function selectPrimaryActiveWorkflow(
+  workflows: WorkflowSummary[],
+): WorkflowSummary | undefined {
+  const active = workflows.filter((workflow) =>
+    ACTIVE_STATES.includes(workflow.state),
+  );
+  if (active.length === 0) return undefined;
+
+  return active.sort((a, b) => {
+    const priorityDiff =
+      (ACTIVE_STATE_PRIORITY[a.state] ?? 99) -
+      (ACTIVE_STATE_PRIORITY[b.state] ?? 99);
+    if (priorityDiff !== 0) return priorityDiff;
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  })[0];
+}
+
+export function pendingApprovalFromWorkflows(
+  workflows: WorkflowSummary[],
+): AiPendingApproval | null {
+  const waiting = workflows.find(
+    (workflow) => workflow.state === "WAITING_FOR_APPROVAL",
+  );
+  if (!waiting) return null;
+  return {
+    workflowId: waiting.id,
+    stepKey: waiting.currentStepKey,
+  };
+}

--- a/src/lib/workflow-ui.ts
+++ b/src/lib/workflow-ui.ts
@@ -52,17 +52,6 @@ export function pendingApprovalFromWorkflows(
   };
 }
 
-export function getWorkflowVisibleQuestionKeys(
-  detail: Pick<WorkflowDetailResult, "workflow">,
-  answers: Record<string, string>,
-): string[] {
-  return getVisibleWorkflowQuestionKeys({
-    missingInputKeys: detail.workflow.missingInputKeys,
-    inputQuestions: detail.workflow.inputQuestions,
-    answers,
-  });
-}
-
 export function humanizeWorkflowKey(key: string): string {
   return key
     .split("_")

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -60,6 +60,7 @@ import { LinkedAccounts } from "@/components/LinkedAccounts";
 import { MembershipSharingCard } from "@/components/MembershipSharingCard";
 import { ConnectedDevicesCard } from "@/components/ConnectedDevicesCard";
 import { WorkflowsCard } from "@/components/WorkflowsCard";
+import { AiAssistantCard } from "@/components/AiAssistantCard";
 import { MembershipPlanUpgradeCard } from "@/components/MembershipPlanUpgradeCard";
 import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
 import { UserInformationCard } from "@/components/UserInformationCard";
@@ -1140,6 +1141,12 @@ const Account = () => {
 
           {hasSessionToken && (
             <div className="mt-8">
+              <AiAssistantCard sessionToken={getSessionToken() ?? ""} />
+            </div>
+          )}
+
+          {hasSessionToken && (
+            <div id="applications" className="mt-8 scroll-mt-24">
               <WorkflowsCard sessionToken={getSessionToken() ?? ""} />
             </div>
           )}

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -515,7 +515,14 @@ const Perks = () => {
   };
 
   const handleViewApplication = async (perk: PerkItem) => {
-    if (!perk.workflowType) return;
+    if (!perk.workflowType) {
+      toast({
+        title: "Application unavailable",
+        description: "This perk is missing workflow configuration. Contact support.",
+        variant: "destructive",
+      });
+      return;
+    }
     const session = getSessionToken();
     if (!session) {
       toast({

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -68,7 +68,7 @@ import {
   type PerkRequestCategory,
   type PerkUserTab,
 } from "@/auth";
-import { listWorkflows, type WorkflowState } from "@/auth/backend";
+import { listWorkflows } from "@/auth/backend";
 import { trackPerksEvent } from "@/lib/product-analytics";
 import { isSafeHttpUrl } from "@/lib/safe-url";
 
@@ -94,15 +94,7 @@ const PERK_TABS: { value: PerkUserTab; label: string }[] = [
   { value: "not_interested", label: "Not Interested" },
 ];
 
-/** Mirrors backend workflow-state.util.ts ACTIVE_STATES — used to prefer an in-progress
- * application over stale terminal ones when reopening a workflow perk's dialog. */
-const ACTIVE_WORKFLOW_STATES: WorkflowState[] = [
-  "CREATED",
-  "WAITING_FOR_INPUT",
-  "READY_TO_EXECUTE",
-  "EXECUTING",
-  "WAITING_FOR_APPROVAL",
-];
+import { selectPrimaryActiveWorkflow } from "@/lib/workflow-ui";
 
 const REQUEST_CATEGORIES: { value: PerkRequestCategory; label: string }[] = [
   { value: "finance", label: "Finance" },
@@ -547,9 +539,10 @@ const Perks = () => {
       (w) => w.workflowType === perk.workflowType,
     );
     const chosen =
-      matches.find((w) => ACTIVE_WORKFLOW_STATES.includes(w.state)) ??
+      selectPrimaryActiveWorkflow(matches) ??
       [...matches].sort(
-        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
       )[0];
     if (!chosen) {
       toast({

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -11,6 +11,7 @@ import {
   Copy,
   CircleCheck,
   ExternalLink,
+  FileText,
   Gift,
   Loader2,
   Lock,
@@ -48,6 +49,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { WorkflowPerkDialog } from "@/components/WorkflowPerkDialog";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import {
@@ -66,6 +68,7 @@ import {
   type PerkRequestCategory,
   type PerkUserTab,
 } from "@/auth";
+import { listWorkflows, type WorkflowState } from "@/auth/backend";
 import { trackPerksEvent } from "@/lib/product-analytics";
 import { isSafeHttpUrl } from "@/lib/safe-url";
 
@@ -75,6 +78,7 @@ const CATEGORY_LABELS: Record<PerkCategory, string> = {
   developer_tools: "Developer Tools",
   startup_growth: "Startup & Growth",
   remote_work: "Remote Work",
+  finance: "Finance",
 };
 
 const ACCESS_BADGE: Record<string, string> = {
@@ -88,6 +92,16 @@ const PERK_TABS: { value: PerkUserTab; label: string }[] = [
   { value: "completed", label: "Completed" },
   { value: "snoozed", label: "Snoozed" },
   { value: "not_interested", label: "Not Interested" },
+];
+
+/** Mirrors backend workflow-state.util.ts ACTIVE_STATES — used to prefer an in-progress
+ * application over stale terminal ones when reopening a workflow perk's dialog. */
+const ACTIVE_WORKFLOW_STATES: WorkflowState[] = [
+  "CREATED",
+  "WAITING_FOR_INPUT",
+  "READY_TO_EXECUTE",
+  "EXECUTING",
+  "WAITING_FOR_APPROVAL",
 ];
 
 const REQUEST_CATEGORIES: { value: PerkRequestCategory; label: string }[] = [
@@ -218,6 +232,10 @@ const Perks = () => {
   const [claimingId, setClaimingId] = useState<string | null>(null);
   const [actionPerkIds, setActionPerkIds] = useState<Set<string>>(new Set());
   const [detailsPerkId, setDetailsPerkId] = useState<string | null>(null);
+  const [workflowDialog, setWorkflowDialog] = useState<{
+    workflowId: string;
+    perkTitle: string;
+  } | null>(null);
   const [requestOpen, setRequestOpen] = useState(false);
   const [requestSubmitting, setRequestSubmitting] = useState(false);
   const [profileDialogOpen, setProfileDialogOpen] = useState(false);
@@ -487,11 +505,54 @@ const Perks = () => {
           description: "Use the copy button for your code at checkout.",
         });
       }
+    } else if (res.redemptionType === "workflow" && res.workflowId) {
+      setWorkflowDialog({ workflowId: res.workflowId, perkTitle: perk.title });
     } else if (res.message) {
       toast({ title: "Request received", description: res.message });
     }
 
     void loadPerks();
+  };
+
+  const handleViewApplication = async (perk: PerkItem) => {
+    if (!perk.workflowType) return;
+    const session = getSessionToken();
+    if (!session) {
+      toast({
+        title: "Session expired",
+        description: "Sign in again to view this application.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setClaimingId(perk.id);
+    const res = await listWorkflows(session);
+    setClaimingId(null);
+    if (!res.ok || !res.data) {
+      toast({
+        title: "Could not load application",
+        description: res.error || "Please try again.",
+        variant: "destructive",
+      });
+      return;
+    }
+    const matches = res.data.workflows.filter(
+      (w) => w.workflowType === perk.workflowType,
+    );
+    const chosen =
+      matches.find((w) => ACTIVE_WORKFLOW_STATES.includes(w.state)) ??
+      [...matches].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      )[0];
+    if (!chosen) {
+      toast({
+        title: "No application found",
+        description: "We couldn't find an application for this perk.",
+        variant: "destructive",
+      });
+      return;
+    }
+    setWorkflowDialog({ workflowId: chosen.id, perkTitle: perk.title });
   };
 
   const runPerkAction = async (
@@ -774,6 +835,7 @@ const Perks = () => {
                         onClaim={() => void handleClaim(perk)}
                         onCopyCode={(code) => void handleCopyCode(code)}
                         onViewDetails={() => setDetailsPerkId(perk.id)}
+                        onViewApplication={() => void handleViewApplication(perk)}
                         onSnooze={() => handleSnooze(perk)}
                         onDismiss={() => handleDismiss(perk)}
                         onRestore={() => handleRestore(perk)}
@@ -809,6 +871,7 @@ const Perks = () => {
                           onClaim={() => void handleClaim(perk)}
                           onCopyCode={(code) => void handleCopyCode(code)}
                           onViewDetails={() => setDetailsPerkId(perk.id)}
+                          onViewApplication={() => void handleViewApplication(perk)}
                           onSnooze={() => handleSnooze(perk)}
                           onDismiss={() => handleDismiss(perk)}
                           onRestore={() => handleRestore(perk)}
@@ -905,7 +968,20 @@ const Perks = () => {
         onClaim={() => {
           if (detailsPerk) void handleClaim(detailsPerk);
         }}
+        onViewApplication={() => {
+          if (detailsPerk) void handleViewApplication(detailsPerk);
+        }}
         onCopyCode={(code) => void handleCopyCode(code)}
+      />
+      <WorkflowPerkDialog
+        open={workflowDialog !== null}
+        sessionToken={getSessionToken() ?? ""}
+        workflowId={workflowDialog?.workflowId ?? null}
+        perkTitle={workflowDialog?.perkTitle ?? ""}
+        onOpenChange={(open) => {
+          if (!open) setWorkflowDialog(null);
+        }}
+        onSettled={() => void loadPerks()}
       />
       <Footer />
     </div>
@@ -952,6 +1028,7 @@ function PerkDetailsDialog({
   claiming,
   onOpenChange,
   onClaim,
+  onViewApplication,
   onCopyCode,
 }: {
   perk: PerkItem | null;
@@ -959,9 +1036,11 @@ function PerkDetailsDialog({
   claiming: boolean;
   onOpenChange: (open: boolean) => void;
   onClaim: () => void;
+  onViewApplication: () => void;
   onCopyCode: (code: string) => void;
 }) {
   const locked = perk ? !perk.accessible && !perk.redeemed : false;
+  const isWorkflowPerk = perk?.redemptionType === "workflow";
   const couponCode = perk?.couponCode?.trim() || undefined;
   const isCouponCard =
     perk?.redemptionType === "coupon_code" && couponCode !== undefined;
@@ -1083,7 +1162,16 @@ function PerkDetailsDialog({
               >
                 Close
               </Button>
-              {!locked ? (
+              {!locked && isWorkflowPerk && perk.redeemed ? (
+                <Button disabled={claiming} onClick={onViewApplication}>
+                  {claiming ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <FileText className="mr-2 h-4 w-4" />
+                  )}
+                  View application
+                </Button>
+              ) : !locked ? (
                 <Button disabled={perk.redeemed || claiming} onClick={onClaim}>
                   {claiming ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -1111,6 +1199,7 @@ function PerkCard({
   onClaim,
   onCopyCode,
   onViewDetails,
+  onViewApplication,
   onSnooze,
   onDismiss,
   onRestore,
@@ -1125,6 +1214,7 @@ function PerkCard({
   onClaim: () => void;
   onCopyCode: (code: string) => void;
   onViewDetails: () => void;
+  onViewApplication: () => void;
   onSnooze: () => void;
   onDismiss: () => void;
   onRestore: () => void;
@@ -1133,6 +1223,7 @@ function PerkCard({
   onNotInterestedToSnoozed: () => void;
 }) {
   const locked = !perk.accessible && !perk.redeemed;
+  const isWorkflowPerk = perk.redemptionType === "workflow";
   const expirationLabel = formatExpirationLabel(perk);
   const couponCode = perk.couponCode?.trim() || undefined;
   const isCouponCard =
@@ -1256,6 +1347,20 @@ function PerkCard({
               {perk.ctaLabel}
             </Button>
           </div>
+        ) : isWorkflowPerk && perk.redeemed ? (
+          <Button
+            className="relative z-20 h-10 w-full"
+            variant="outline"
+            disabled={locked || claiming}
+            onClick={onViewApplication}
+          >
+            {claiming ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <FileText className="mr-2 h-4 w-4" />
+            )}
+            View application
+          </Button>
         ) : (
           <Button
             className="relative z-20 h-10 w-full"

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/accordion";
 import { ContactSalesDialog } from "@/components/ContactSalesForm";
 import PricingNoticeTooltip from "@/components/PricingNoticeTooltip";
-import { enterprisePlan, featureComparison, featureComparisonValueForPlan, faqs } from "@/constants/pricing";
+import { enterprisePlan, featureComparison, featureComparisonValueForPlan, faqs, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS } from "@/constants/pricing";
 import { fetchSubscriptionPlans } from "@/auth/backend";
 import { useAnnualUpgrade } from "@/hooks/use-annual-upgrade";
 import {
@@ -133,6 +133,9 @@ const Pricing = () => {
 
   const [billingPeriod, setBillingPeriod] = useState<"monthly" | "annual">(
     "annual",
+  );
+  const [businessSeatCount, setBusinessSeatCount] = useState(
+    DEFAULT_BUSINESS_SEATS,
   );
   const [plans, setPlans] = useState<PricingPlan[]>([]);
   const [loading, setLoading] = useState(true);
@@ -307,11 +310,6 @@ const Pricing = () => {
               const annualBillingDetail = isAnnual
                 ? formatAnnualBillingDetail(plan)
                 : null;
-              const showFamilyPlanUpgrade =
-                ctaKind === "manage_account" &&
-                plan.name === "Family" &&
-                membershipTier === "individual" &&
-                showMembershipPlanUpgrade;
               const showBusinessPlanUpgrade =
                 ctaKind === "manage_account" &&
                 plan.name === "Business" &&
@@ -354,7 +352,10 @@ const Pricing = () => {
                         {annualHeroPriceDisplay(plan, isAnnual)}
                       </span>
                       {period && (
-                        <span className="text-muted-foreground">{period}</span>
+                        <span className="text-muted-foreground">
+                          {period}
+                          {plan.isPerSeat ? " per seat" : ""}
+                        </span>
                       )}
                       {plan.name !== "Enterprise" && <PricingNoticeTooltip />}
                     </div>
@@ -371,6 +372,52 @@ const Pricing = () => {
                         {annualBillingDetail}
                       </p>
                     )}
+                    {plan.isPerSeat && plan.monthlyPrice !== null ? (
+                      <div className="mt-4 space-y-2 rounded-lg border border-border/80 bg-muted/30 p-3">
+                        <p className="text-sm font-medium text-foreground">
+                          Seats
+                        </p>
+                        <div className="flex items-center gap-3">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            className="h-8 w-8"
+                            disabled={businessSeatCount <= MIN_BUSINESS_SEATS}
+                            onClick={() =>
+                              setBusinessSeatCount((count) =>
+                                Math.max(MIN_BUSINESS_SEATS, count - 1),
+                              )
+                            }
+                          >
+                            −
+                          </Button>
+                          <span className="min-w-[2rem] text-center text-lg font-semibold">
+                            {businessSeatCount}
+                          </span>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() =>
+                              setBusinessSeatCount((count) => count + 1)
+                            }
+                          >
+                            +
+                          </Button>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          Total: $
+                          {(
+                            (isAnnual ? plan.annualPrice : plan.monthlyPrice) ??
+                            0
+                          ) * businessSeatCount}
+                          {isAnnual ? "/year" : "/month"} for {businessSeatCount}{" "}
+                          seats
+                        </p>
+                      </div>
+                    ) : null}
                   </div>
 
                   {plan.name === "Enterprise" ? (
@@ -387,7 +434,7 @@ const Pricing = () => {
                         {plan.buttonText}
                       </Button>
                     </ContactSalesDialog>
-                  ) : showFamilyPlanUpgrade || showBusinessPlanUpgrade ? (
+                  ) : showBusinessPlanUpgrade ? (
                     <Button
                       onClick={() => void openPlanChangePortal()}
                       disabled={portalLoading}
@@ -404,10 +451,8 @@ const Pricing = () => {
                           <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                           Opening billing…
                         </>
-                      ) : showBusinessPlanUpgrade ? (
-                        "Upgrade to Business"
                       ) : (
-                        "Upgrade to Family"
+                        "Upgrade to Business"
                       )}
                     </Button>
                   ) : ctaKind === "manage_account" &&
@@ -455,6 +500,12 @@ const Pricing = () => {
                             ? plan.annualId || ""
                             : plan.monthlyId || "",
                         });
+                        if (plan.isPerSeat) {
+                          queryParams.set(
+                            "seats",
+                            String(businessSeatCount),
+                          );
+                        }
                         navigate(`/subscribe?${queryParams.toString()}`);
                       }}
                       disabled={ctaKind === "loading"}
@@ -721,7 +772,7 @@ const Pricing = () => {
             <p className="text-xl text-muted-foreground mb-8">
               {ctaKind === "manage_account"
                 ? showMembershipPlanUpgrade
-                  ? "Upgrade your plan to share KeenVPN with family or your team."
+                  ? "Upgrade to Business to buy seats and invite your team."
                   : "Manage billing, plan details, and settings in one place."
                 : ctaKind === "subscribe"
                   ? "Choose a plan and subscribe to get full protection."

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/accordion";
 import { ContactSalesDialog } from "@/components/ContactSalesForm";
 import PricingNoticeTooltip from "@/components/PricingNoticeTooltip";
-import { enterprisePlan, featureComparison, featureComparisonValueForPlan, faqs, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS, MAX_BUSINESS_SEATS } from "@/constants/pricing";
+import { enterprisePlan, featureComparison, featureComparisonValueForPlan, faqs, DEFAULT_BUSINESS_SEATS, MAX_BUSINESS_SEATS, resolvePlanDefaultSeats, resolvePlanMinSeats } from "@/constants/pricing";
 import { fetchSubscriptionPlans } from "@/auth/backend";
 import { useAnnualUpgrade } from "@/hooks/use-annual-upgrade";
 import {
@@ -145,8 +145,18 @@ const Pricing = () => {
     () => plans.find((p) => p.name === "Individual" || p.name === "Premium"),
     [plans],
   );
+  const businessPlan = useMemo(
+    () => plans.find((p) => p.isPerSeat),
+    [plans],
+  );
+  const businessMinSeats = resolvePlanMinSeats(businessPlan);
+  const businessDefaultSeats = resolvePlanDefaultSeats(businessPlan);
   const annualSavingsLabel =
     premiumPlan?.annualSavingsLabel ?? DEFAULT_ANNUAL_SAVINGS_LABEL;
+
+  useEffect(() => {
+    setBusinessSeatCount(businessDefaultSeats);
+  }, [businessDefaultSeats]);
 
   useEffect(() => {
     if (billingPeriod !== "annual" || annualViewTrackedRef.current) {
@@ -383,10 +393,10 @@ const Pricing = () => {
                             variant="outline"
                             size="icon"
                             className="h-8 w-8"
-                            disabled={businessSeatCount <= MIN_BUSINESS_SEATS}
+                            disabled={businessSeatCount <= businessMinSeats}
                             onClick={() =>
                               setBusinessSeatCount((count) =>
-                                Math.max(MIN_BUSINESS_SEATS, count - 1),
+                                Math.max(businessMinSeats, count - 1),
                               )
                             }
                           >
@@ -413,9 +423,9 @@ const Pricing = () => {
                         <p className="text-xs text-muted-foreground">
                           Total: $
                           {(
-                            (isAnnual ? plan.annualPrice : plan.monthlyPrice) ??
-                            0
-                          ) * businessSeatCount}
+                            ((isAnnual ? plan.annualPrice : plan.monthlyPrice) ??
+                              0) * businessSeatCount
+                          ).toFixed(2)}
                           {isAnnual ? "/year" : "/month"} for {businessSeatCount}{" "}
                           seats
                         </p>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/accordion";
 import { ContactSalesDialog } from "@/components/ContactSalesForm";
 import PricingNoticeTooltip from "@/components/PricingNoticeTooltip";
-import { enterprisePlan, featureComparison, featureComparisonValueForPlan, faqs, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS } from "@/constants/pricing";
+import { enterprisePlan, featureComparison, featureComparisonValueForPlan, faqs, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS, MAX_BUSINESS_SEATS } from "@/constants/pricing";
 import { fetchSubscriptionPlans } from "@/auth/backend";
 import { useAnnualUpgrade } from "@/hooks/use-annual-upgrade";
 import {
@@ -400,8 +400,11 @@ const Pricing = () => {
                             variant="outline"
                             size="icon"
                             className="h-8 w-8"
+                            disabled={businessSeatCount >= MAX_BUSINESS_SEATS}
                             onClick={() =>
-                              setBusinessSeatCount((count) => count + 1)
+                              setBusinessSeatCount((count) =>
+                                Math.min(MAX_BUSINESS_SEATS, count + 1),
+                              )
                             }
                           >
                             +

--- a/src/pages/Subscribe.tsx
+++ b/src/pages/Subscribe.tsx
@@ -23,7 +23,13 @@ import {
   recordSignupStarted,
   CHECKOUT_ERROR_SESSION_EXPIRED,
 } from "@/auth/backend";
-import { enterprisePlan, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS, MAX_BUSINESS_SEATS } from "@/constants/pricing";
+import {
+  enterprisePlan,
+  DEFAULT_BUSINESS_SEATS,
+  MIN_BUSINESS_SEATS,
+  MAX_BUSINESS_SEATS,
+  resolvePlanMinSeats,
+} from "@/constants/pricing";
 import {
   canStartFreeTrial,
   getSubscriptionCtaLabel,
@@ -67,13 +73,6 @@ const isPerSeatPlan = (plan: ApiPlan | PricingPlan | null): boolean => {
     );
   }
   return false;
-};
-
-const getPlanMinSeats = (plan: ApiPlan | PricingPlan | null): number => {
-  if (plan && "minSeats" in plan && typeof plan.minSeats === "number") {
-    return plan.minSeats;
-  }
-  return MIN_BUSINESS_SEATS;
 };
 
 const getTierLabel = (tier: string) =>
@@ -236,7 +235,7 @@ const Subscribe = () => {
 
   useEffect(() => {
     if (!isPerSeatPlan(selectedPlan)) return;
-    const minSeats = getPlanMinSeats(selectedPlan);
+    const minSeats = resolvePlanMinSeats(selectedPlan);
     setSeatCount((count) =>
       Math.max(minSeats, Math.min(MAX_BUSINESS_SEATS, count)),
     );
@@ -735,10 +734,10 @@ const Subscribe = () => {
                         variant="outline"
                         size="icon"
                         className="h-8 w-8"
-                        disabled={seatCount <= getPlanMinSeats(selectedPlan)}
+                        disabled={seatCount <= resolvePlanMinSeats(selectedPlan)}
                         onClick={() =>
                           setSeatCount((count) =>
-                            Math.max(getPlanMinSeats(selectedPlan), count - 1),
+                            Math.max(resolvePlanMinSeats(selectedPlan), count - 1),
                           )
                         }
                       >

--- a/src/pages/Subscribe.tsx
+++ b/src/pages/Subscribe.tsx
@@ -59,9 +59,21 @@ const isPerSeatPlan = (plan: ApiPlan | PricingPlan | null): boolean => {
   if ("isPerSeat" in plan && plan.isPerSeat) return true;
   if ("id" in plan) {
     const id = plan.id.toLowerCase();
-    return id.includes("team") || id.includes("business");
+    return (
+      id.includes("team") ||
+      id.includes("business") ||
+      id.includes("family_plus") ||
+      id.includes("familyplus")
+    );
   }
   return false;
+};
+
+const getPlanMinSeats = (plan: ApiPlan | PricingPlan | null): number => {
+  if (plan && "minSeats" in plan && typeof plan.minSeats === "number") {
+    return plan.minSeats;
+  }
+  return MIN_BUSINESS_SEATS;
 };
 
 const getTierLabel = (tier: string) =>
@@ -216,11 +228,19 @@ const Subscribe = () => {
   const initialSeatCount = (() => {
     const parsed = Number(seatsParam);
     return Number.isInteger(parsed) && parsed >= MIN_BUSINESS_SEATS
-      ? parsed
+      ? Math.min(MAX_BUSINESS_SEATS, parsed)
       : DEFAULT_BUSINESS_SEATS;
   })();
   const [seatCount, setSeatCount] = useState(initialSeatCount);
   const { toast } = useToast();
+
+  useEffect(() => {
+    if (!isPerSeatPlan(selectedPlan)) return;
+    const minSeats = getPlanMinSeats(selectedPlan);
+    setSeatCount((count) =>
+      Math.max(minSeats, Math.min(MAX_BUSINESS_SEATS, count)),
+    );
+  }, [selectedPlan]);
   const {
     user,
     loading,
@@ -715,10 +735,10 @@ const Subscribe = () => {
                         variant="outline"
                         size="icon"
                         className="h-8 w-8"
-                        disabled={seatCount <= MIN_BUSINESS_SEATS}
+                        disabled={seatCount <= getPlanMinSeats(selectedPlan)}
                         onClick={() =>
                           setSeatCount((count) =>
-                            Math.max(MIN_BUSINESS_SEATS, count - 1),
+                            Math.max(getPlanMinSeats(selectedPlan), count - 1),
                           )
                         }
                       >
@@ -743,7 +763,7 @@ const Subscribe = () => {
                       </Button>
                     </div>
                     <p className="text-xs text-muted-foreground">
-                      Total: ${selectedPlan.price * seatCount}
+                      Total: ${(selectedPlan.price * seatCount).toFixed(2)}
                       {isAnnualPlan(selectedPlan) ? "/year" : "/month"} for{" "}
                       {seatCount} seats
                       {isAnnualPlan(selectedPlan)

--- a/src/pages/Subscribe.tsx
+++ b/src/pages/Subscribe.tsx
@@ -23,7 +23,7 @@ import {
   recordSignupStarted,
   CHECKOUT_ERROR_SESSION_EXPIRED,
 } from "@/auth/backend";
-import { enterprisePlan, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS } from "@/constants/pricing";
+import { enterprisePlan, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS, MAX_BUSINESS_SEATS } from "@/constants/pricing";
 import {
   canStartFreeTrial,
   getSubscriptionCtaLabel,
@@ -732,7 +732,12 @@ const Subscribe = () => {
                         variant="outline"
                         size="icon"
                         className="h-8 w-8"
-                        onClick={() => setSeatCount((count) => count + 1)}
+                        disabled={seatCount >= MAX_BUSINESS_SEATS}
+                        onClick={() =>
+                          setSeatCount((count) =>
+                            Math.min(MAX_BUSINESS_SEATS, count + 1),
+                          )
+                        }
                       >
                         +
                       </Button>

--- a/src/pages/Subscribe.tsx
+++ b/src/pages/Subscribe.tsx
@@ -23,7 +23,7 @@ import {
   recordSignupStarted,
   CHECKOUT_ERROR_SESSION_EXPIRED,
 } from "@/auth/backend";
-import { enterprisePlan } from "@/constants/pricing";
+import { enterprisePlan, DEFAULT_BUSINESS_SEATS, MIN_BUSINESS_SEATS } from "@/constants/pricing";
 import {
   canStartFreeTrial,
   getSubscriptionCtaLabel,
@@ -35,11 +35,8 @@ const getPlanBillingPeriod = (plan: ApiPlan) =>
 
 const isAnnualPlan = (plan: ApiPlan) => getPlanBillingPeriod(plan) === "year";
 
-const getPlanFamily = (plan: ApiPlan) => {
+const getPlanTier = (plan: ApiPlan) => {
   const id = plan.id.toLowerCase();
-  if (id.includes("family") && !id.includes("family_plus") && !id.includes("familyplus")) {
-    return "family";
-  }
   if (
     id.includes("team") ||
     id.includes("business") ||
@@ -54,9 +51,18 @@ const getPlanFamily = (plan: ApiPlan) => {
 
 const PLAN_TIER_OPTIONS = [
   { id: "premium", label: "Individual" },
-  { id: "family", label: "Family" },
   { id: "team", label: "Business" },
 ] as const;
+
+const isPerSeatPlan = (plan: ApiPlan | PricingPlan | null): boolean => {
+  if (!plan) return false;
+  if ("isPerSeat" in plan && plan.isPerSeat) return true;
+  if ("id" in plan) {
+    const id = plan.id.toLowerCase();
+    return id.includes("team") || id.includes("business");
+  }
+  return false;
+};
 
 const getTierLabel = (tier: string) =>
   PLAN_TIER_OPTIONS.find((option) => option.id === tier)?.label ?? tier;
@@ -206,6 +212,14 @@ const Subscribe = () => {
   const [planLoading, setPlanLoading] = useState(true);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const seatsParam = searchParams.get("seats");
+  const initialSeatCount = (() => {
+    const parsed = Number(seatsParam);
+    return Number.isInteger(parsed) && parsed >= MIN_BUSINESS_SEATS
+      ? parsed
+      : DEFAULT_BUSINESS_SEATS;
+  })();
+  const [seatCount, setSeatCount] = useState(initialSeatCount);
   const { toast } = useToast();
   const {
     user,
@@ -358,13 +372,13 @@ const Subscribe = () => {
   }, [user]);
 
   const availableTiers = PLAN_TIER_OPTIONS.map((option) => option.id).filter(
-    (tier) => allPlans.some((plan) => getPlanFamily(plan) === tier),
+    (tier) => allPlans.some((plan) => getPlanTier(plan) === tier),
   );
 
   const applyTierSelection = useCallback(
     (tier: string, plans: ApiPlan[], preferredPlanId?: string | null) => {
       const options = sortPlansByBillingPeriod(
-        plans.filter((plan) => getPlanFamily(plan) === tier),
+        plans.filter((plan) => getPlanTier(plan) === tier),
       );
       const requestedPlan = preferredPlanId
         ? options.find((plan) => matchesRequestedPlan(plan, preferredPlanId))
@@ -404,11 +418,11 @@ const Subscribe = () => {
                 matchesRequestedPlan(plan, planIdParam),
               )
             : null;
-          const tierOrder = ["premium", "family", "team"];
+          const tierOrder = ["premium", "team"];
           const initialTier = requestedReturnedPlan
-            ? getPlanFamily(requestedReturnedPlan)
+            ? getPlanTier(requestedReturnedPlan)
             : tierOrder.find((tier) =>
-                response.plans.some((plan) => getPlanFamily(plan) === tier),
+                response.plans.some((plan) => getPlanTier(plan) === tier),
               ) ?? "premium";
 
           applyTierSelection(initialTier, response.plans, planIdParam);
@@ -504,6 +518,7 @@ const Subscribe = () => {
         planId,
         successUrl,
         cancelUrl,
+        isPerSeatPlan(selectedPlan) ? seatCount : undefined,
       );
 
       if (!result.success) {
@@ -690,6 +705,48 @@ const Subscribe = () => {
                   onSelect={setSelectedPlan}
                   className="mb-6"
                 />
+
+                {isPerSeatPlan(selectedPlan) && "price" in selectedPlan ? (
+                  <div className="mb-6 space-y-2 rounded-lg border border-border/80 bg-muted/30 p-4">
+                    <p className="text-sm font-medium text-foreground">Seats</p>
+                    <div className="flex items-center gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8"
+                        disabled={seatCount <= MIN_BUSINESS_SEATS}
+                        onClick={() =>
+                          setSeatCount((count) =>
+                            Math.max(MIN_BUSINESS_SEATS, count - 1),
+                          )
+                        }
+                      >
+                        −
+                      </Button>
+                      <span className="min-w-[2rem] text-center text-lg font-semibold">
+                        {seatCount}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => setSeatCount((count) => count + 1)}
+                      >
+                        +
+                      </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Total: ${selectedPlan.price * seatCount}
+                      {isAnnualPlan(selectedPlan) ? "/year" : "/month"} for{" "}
+                      {seatCount} seats
+                      {isAnnualPlan(selectedPlan)
+                        ? ` ($${(selectedPlan.price / 12).toFixed(2)}/seat/mo)`
+                        : ` ($${selectedPlan.price}/seat/mo)`}
+                    </p>
+                  </div>
+                ) : null}
 
                 <div className="mb-6 p-4 bg-accent/10 rounded-lg border border-accent/20">
                   <p className="text-sm text-muted-foreground">

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -93,7 +93,7 @@ const Support = () => {
         },
         {
           q: "How many devices can I use with one account?",
-          a: "Device limits depend on your plan: Individual supports up to 10 simultaneous connections, Family up to 12, and Business up to 14 — competitive with leading VPN providers. Connect on macOS, iOS, Windows, and Android. Manage active devices from your account page or in the app settings.",
+          a: "Device limits depend on your plan: Individual supports up to 3 simultaneous connections, while Business includes 5 connected devices per seat. You can install KeenVPN on macOS, iOS, Windows, and Android, then manage active devices from your account page or in the app settings.",
         },
       ],
     },

--- a/src/pages/admin/AdminPerks.tsx
+++ b/src/pages/admin/AdminPerks.tsx
@@ -54,12 +54,22 @@ const PERK_CATEGORIES: { value: PerkCategory; label: string }[] = [
   { value: "developer_tools", label: "Developer Tools" },
   { value: "startup_growth", label: "Startup & Growth" },
   { value: "remote_work", label: "Remote Work" },
+  { value: "finance", label: "Finance" },
 ];
 
 const REDEMPTION_TYPES: { value: PerkRedemptionType; label: string }[] = [
   { value: "external_link", label: "External link" },
   { value: "coupon_code", label: "Coupon code" },
   { value: "invite_only", label: "Invite only" },
+  { value: "workflow", label: "Workflow (auto-apply)" },
+];
+
+/** Registered backend workflow types available for "workflow" redemption perks —
+ * see vpn-backend-service-v2/src/workflows/workflow-types/index.ts. */
+const WORKFLOW_TYPE_OPTIONS: { value: string; label: string }[] = [
+  { value: "chase_signup", label: "Chase — Account signup (VIG)" },
+  { value: "airwallex_signup", label: "Airwallex — Business signup" },
+  { value: "mercury_signup", label: "Mercury — Business signup" },
 ];
 
 const ACCESS_LEVELS = [
@@ -85,6 +95,7 @@ interface PerkFormState {
   redemptionType: PerkRedemptionType;
   redemptionUrl: string;
   couponCode: string;
+  workflowType: string;
   accessLevel: "free" | "paid" | "annual";
   isFeatured: boolean;
   isActive: boolean;
@@ -225,6 +236,7 @@ const emptyForm = (): PerkFormState => ({
   redemptionType: "external_link",
   redemptionUrl: "",
   couponCode: "",
+  workflowType: "",
   accessLevel: "paid",
   isFeatured: false,
   isActive: true,
@@ -247,6 +259,7 @@ function formToCreatePayload(form: PerkFormState): CreateAdminPerkPayload {
     redemptionType: form.redemptionType,
     redemptionUrl: form.redemptionUrl.trim() || undefined,
     couponCode: form.couponCode.trim() || undefined,
+    workflowType: form.workflowType.trim() || undefined,
     accessLevel: form.accessLevel,
     isFeatured: form.isFeatured,
     isActive: form.isActive,
@@ -270,6 +283,7 @@ function perkToForm(perk: AdminPerk): PerkFormState {
     redemptionType: perk.redemptionType,
     redemptionUrl: perk.redemptionUrl ?? "",
     couponCode: perk.couponCode ?? "",
+    workflowType: perk.workflowType ?? "",
     accessLevel: perk.accessLevel,
     isFeatured: perk.isFeatured,
     isActive: perk.isActive,
@@ -589,6 +603,7 @@ export default function AdminPerks() {
         redemptionType: form.redemptionType,
         redemptionUrl: form.redemptionUrl.trim() || null,
         couponCode: form.couponCode.trim() || null,
+        workflowType: form.workflowType.trim() || null,
         accessLevel: form.accessLevel,
         isFeatured: form.isFeatured,
         isActive: form.isActive,
@@ -924,6 +939,12 @@ export default function AdminPerks() {
                     <td className="px-3 py-2 capitalize">{perk.accessLevel}</td>
                     <td className="px-3 py-2">
                       {perk.redemptionType.replace(/_/g, " ")}
+                      {perk.redemptionType === "workflow" &&
+                      perk.workflowType ? (
+                        <div className="text-xs text-muted-foreground">
+                          {perk.workflowType}
+                        </div>
+                      ) : null}
                     </td>
                     <td className="px-3 py-2 text-xs text-muted-foreground">
                       {formatExtensionSiteSummary(perk.extensionDomains)}
@@ -1596,6 +1617,32 @@ export default function AdminPerks() {
                     (e.g. partner checkout or billing).
                   </p>
                 </div>
+              </div>
+            ) : null}
+            {form.redemptionType === "workflow" ? (
+              <div>
+                <Label htmlFor="perk-workflow-type">Workflow type</Label>
+                <Select
+                  value={form.workflowType || undefined}
+                  onValueChange={(value) =>
+                    setForm((prev) => ({ ...prev, workflowType: value }))
+                  }
+                >
+                  <SelectTrigger id="perk-workflow-type" className="mt-1">
+                    <SelectValue placeholder="Select a workflow type" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {WORKFLOW_TYPE_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Claiming this perk starts the AI Workflow Engine application
+                  for the selected partner instead of opening a link.
+                </p>
               </div>
             ) : null}
             <div className="grid gap-3 sm:grid-cols-2">

--- a/src/pages/admin/AdminPerks.tsx
+++ b/src/pages/admin/AdminPerks.tsx
@@ -590,6 +590,12 @@ export default function AdminPerks() {
       return;
     }
 
+    if (form.redemptionType === "workflow" && !form.workflowType.trim()) {
+      setSaving(false);
+      setDialogError("Workflow type is required for workflow perks.");
+      return;
+    }
+
     const extensionDomains = extensionDomainsFromFormRows(form.extensionDomains);
 
     if (editingId) {


### PR DESCRIPTION
## Summary
- Add workflow-type perk claim UI on Perks (`WorkflowPerkDialog` + dynamic VIG question fields) and finance category support
- Add AI Assistant card on Account (hidden when backend orchestrator is disabled)
- Replace Family with per-seat Business on Pricing/Subscribe, including seat stepper at checkout
- Add seat buy/reduce UI on Membership Sharing card for Business owners

## Test plan
- [ ] Confirm Pricing shows Individual + Business only; Business seat stepper updates total
- [ ] Subscribe flow passes seat count to checkout for Business plans
- [ ] Claim a workflow perk on Perks opens VIG form, approval step, and status polling
- [ ] Account → Membership sharing shows seat management for Business Stripe subs
- [ ] AI Assistant card is hidden when `AI_ORCHESTRATOR_ENABLED=false` on backend
- [ ] Deploy after backend PR #257 (migration + workflow/perk APIs) is on staging


Made with [Cursor](https://cursor.com)