### PR TITLE
feat(vault): add secure vault UI and workflow consent flow

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -5464,6 +5464,7 @@ export async function restoreDeviceConnection(
 export type WorkflowState =
   | "CREATED"
   | "WAITING_FOR_INPUT"
+  | "WAITING_FOR_VAULT_CONSENT"
   | "READY_TO_EXECUTE"
   | "EXECUTING"
   | "WAITING_FOR_APPROVAL"
@@ -5659,6 +5660,192 @@ export async function cancelWorkflow(
     `/${workflowId}/cancel`,
     { method: "POST" },
     "Failed to cancel workflow",
+  );
+}
+
+export interface VaultAccessRequestField {
+  fieldKey: string;
+  label: string;
+}
+
+export interface VaultAccessRequestInfo {
+  id: string;
+  workflowId: string;
+  status: string;
+  requestedFieldKeys: string[];
+  fields: VaultAccessRequestField[];
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export async function getWorkflowVaultAccess(
+  sessionToken: string,
+  workflowId: string,
+): Promise<
+  WorkflowApiResult<{ success: boolean; request: VaultAccessRequestInfo }>
+> {
+  return workflowRequest(
+    sessionToken,
+    `/${workflowId}/vault-access`,
+    { method: "GET" },
+    "Failed to load vault access request",
+  );
+}
+
+export async function approveWorkflowVaultAccess(
+  sessionToken: string,
+  workflowId: string,
+): Promise<WorkflowApiResult<{ success: boolean } & WorkflowDetailResult>> {
+  return workflowRequest(
+    sessionToken,
+    `/${workflowId}/vault-access/approve`,
+    { method: "POST" },
+    "Failed to approve vault access",
+  );
+}
+
+export async function denyWorkflowVaultAccess(
+  sessionToken: string,
+  workflowId: string,
+): Promise<WorkflowApiResult<{ success: boolean } & WorkflowDetailResult>> {
+  return workflowRequest(
+    sessionToken,
+    `/${workflowId}/vault-access/deny`,
+    { method: "POST" },
+    "Failed to deny vault access",
+  );
+}
+
+// ---------------------------------------------------------------------
+// Secure User Vault
+// ---------------------------------------------------------------------
+
+export type VaultFieldInputType =
+  | "text"
+  | "date"
+  | "ssn"
+  | "address"
+  | "number";
+
+export type VaultFieldCategory =
+  | "IDENTITY"
+  | "ADDRESS"
+  | "EMPLOYMENT"
+  | "FINANCIAL";
+
+export interface VaultFieldMetadata {
+  fieldKey: string;
+  category: VaultFieldCategory;
+  label: string;
+  inputType: VaultFieldInputType;
+  isStored: boolean;
+  verificationStatus: string;
+  lastUpdatedAt: string | null;
+  confirmedAt: string | null;
+  maskedPreview: string | null;
+}
+
+export interface VaultOverviewSection {
+  category: VaultFieldCategory;
+  fields: VaultFieldMetadata[];
+}
+
+interface VaultApiResult<T> {
+  ok: boolean;
+  data?: T;
+  error?: string;
+  status?: number;
+}
+
+async function vaultRequest<T>(
+  sessionToken: string,
+  path: string,
+  init: RequestInit,
+  fallbackError: string,
+): Promise<VaultApiResult<T>> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/user/vault${path}`, {
+      credentials: "include",
+      ...init,
+      headers: {
+        Authorization: `Bearer ${sessionToken}`,
+        ...(init.body ? { "Content-Type": "application/json" } : {}),
+        ...init.headers,
+      },
+    });
+    const raw: unknown = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      if (response.status === 404 && path === "") {
+        return {
+          ok: false,
+          status: 404,
+          error: "Secure vault is not available",
+        };
+      }
+      return {
+        ok: false,
+        status: response.status,
+        error: extractBackendErrorMessage(raw, fallbackError),
+      };
+    }
+    return { ok: true, status: response.status, data: raw as T };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : fallbackError,
+    };
+  }
+}
+
+export async function getVaultOverview(sessionToken: string) {
+  return vaultRequest<{
+    success: boolean;
+    sections: VaultOverviewSection[];
+    fields: VaultFieldMetadata[];
+  }>(sessionToken, "", { method: "GET" }, "Failed to load secure vault");
+}
+
+export async function getVaultFieldValue(
+  sessionToken: string,
+  fieldKey: string,
+) {
+  return vaultRequest<{
+    success: boolean;
+    field: { fieldKey: string; value: string };
+  }>(
+    sessionToken,
+    `/fields/${encodeURIComponent(fieldKey)}`,
+    { method: "GET" },
+    "Failed to load vault field",
+  );
+}
+
+export async function upsertVaultField(
+  sessionToken: string,
+  fieldKey: string,
+  value: string,
+  confirmAccurate = false,
+) {
+  return vaultRequest<{ success: boolean; fieldKey: string }>(
+    sessionToken,
+    `/fields/${encodeURIComponent(fieldKey)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ value, confirmAccurate }),
+    },
+    "Failed to save vault field",
+  );
+}
+
+export async function deleteVaultField(
+  sessionToken: string,
+  fieldKey: string,
+) {
+  return vaultRequest<{ success: boolean; fieldKey: string }>(
+    sessionToken,
+    `/fields/${encodeURIComponent(fieldKey)}`,
+    { method: "DELETE" },
+    "Failed to delete vault field",
   );
 }
 

--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -1,4 +1,8 @@
 import type { ApiPlan } from "@/lib/pricing";
+import type {
+  VaultFieldCategory,
+  VaultFieldInputType,
+} from "@/lib/vault-fields";
 import { BackendAuthResponse, SubscriptionData, TrialData } from "./types";
 import {
   getReferralTokenFromStorage,
@@ -5720,18 +5724,7 @@ export async function denyWorkflowVaultAccess(
 // Secure User Vault
 // ---------------------------------------------------------------------
 
-export type VaultFieldInputType =
-  | "text"
-  | "date"
-  | "ssn"
-  | "address"
-  | "number";
-
-export type VaultFieldCategory =
-  | "IDENTITY"
-  | "ADDRESS"
-  | "EMPLOYMENT"
-  | "FINANCIAL";
+export type { VaultFieldCategory, VaultFieldInputType } from "@/lib/vault-fields";
 
 export interface VaultFieldMetadata {
   fieldKey: string;

--- a/src/components/AiAssistantCard.tsx
+++ b/src/components/AiAssistantCard.tsx
@@ -20,7 +20,8 @@ import {
   type AiPendingApproval,
 } from "@/auth/backend";
 import { cn } from "@/lib/utils";
-import { pendingApprovalFromWorkflows } from "@/lib/workflow-ui";
+import { pendingApprovalFromWorkflows, pendingVaultConsentFromWorkflows } from "@/lib/workflow-ui";
+import { WORKFLOW_UPDATED_EVENT } from "@/lib/workflow-events";
 
 interface AiAssistantCardProps {
   sessionToken: string;
@@ -49,6 +50,8 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
   const [sending, setSending] = useState(false);
   const [pendingApproval, setPendingApproval] =
     useState<AiPendingApproval | null>(null);
+  const [pendingVaultConsentWorkflowId, setPendingVaultConsentWorkflowId] =
+    useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const loadGeneration = useRef(0);
 
@@ -94,6 +97,10 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
       setPendingApproval(
         pendingApprovalFromWorkflows(workflowsRes.data.workflows),
       );
+      const vaultConsent = pendingVaultConsentFromWorkflows(
+        workflowsRes.data.workflows,
+      );
+      setPendingVaultConsentWorkflowId(vaultConsent?.id ?? null);
     }
 
     setLoading(false);
@@ -104,6 +111,12 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
     return () => {
       loadGeneration.current += 1;
     };
+  }, [load]);
+
+  useEffect(() => {
+    const refresh = () => void load();
+    window.addEventListener(WORKFLOW_UPDATED_EVENT, refresh);
+    return () => window.removeEventListener(WORKFLOW_UPDATED_EVENT, refresh);
   }, [load]);
 
   useEffect(() => {
@@ -217,6 +230,23 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
       </CardHeader>
       <CardContent className="space-y-4">
         {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {pendingVaultConsentWorkflowId && (
+          <div className="flex items-start gap-2 rounded-md bg-muted/40 p-3 text-sm">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden />
+            <p>
+              An application needs your permission to access information in your{" "}
+              <a href="#vault" className="font-medium underline">
+                Secure Vault
+              </a>
+              . Review the request in{" "}
+              <a href="#applications" className="font-medium underline">
+                Applications
+              </a>
+              .
+            </p>
+          </div>
+        )}
 
         {pendingApproval && (
           <div className="flex items-start gap-2 rounded-md bg-muted/40 p-3 text-sm">

--- a/src/components/AiAssistantCard.tsx
+++ b/src/components/AiAssistantCard.tsx
@@ -55,6 +55,19 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const loadGeneration = useRef(0);
 
+  const refreshWorkflowState = useCallback(async () => {
+    const workflowsRes = await listWorkflows(sessionToken);
+    if (workflowsRes.ok && workflowsRes.data) {
+      setPendingApproval(
+        pendingApprovalFromWorkflows(workflowsRes.data.workflows),
+      );
+      const vaultConsent = pendingVaultConsentFromWorkflows(
+        workflowsRes.data.workflows,
+      );
+      setPendingVaultConsentWorkflowId(vaultConsent?.id ?? null);
+    }
+  }, [sessionToken]);
+
   const load = useCallback(async () => {
     const generation = ++loadGeneration.current;
     setLoading(true);
@@ -91,20 +104,11 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
       }
     }
 
-    const workflowsRes = await listWorkflows(sessionToken);
     if (generation !== loadGeneration.current) return;
-    if (workflowsRes.ok && workflowsRes.data) {
-      setPendingApproval(
-        pendingApprovalFromWorkflows(workflowsRes.data.workflows),
-      );
-      const vaultConsent = pendingVaultConsentFromWorkflows(
-        workflowsRes.data.workflows,
-      );
-      setPendingVaultConsentWorkflowId(vaultConsent?.id ?? null);
-    }
+    await refreshWorkflowState();
 
     setLoading(false);
-  }, [sessionToken]);
+  }, [sessionToken, refreshWorkflowState]);
 
   useEffect(() => {
     void load();
@@ -114,10 +118,10 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
   }, [load]);
 
   useEffect(() => {
-    const refresh = () => void load();
+    const refresh = () => void refreshWorkflowState();
     window.addEventListener(WORKFLOW_UPDATED_EVENT, refresh);
     return () => window.removeEventListener(WORKFLOW_UPDATED_EVENT, refresh);
-  }, [load]);
+  }, [refreshWorkflowState]);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });

--- a/src/components/AiAssistantCard.tsx
+++ b/src/components/AiAssistantCard.tsx
@@ -55,18 +55,24 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const loadGeneration = useRef(0);
 
-  const refreshWorkflowState = useCallback(async () => {
-    const workflowsRes = await listWorkflows(sessionToken);
-    if (workflowsRes.ok && workflowsRes.data) {
-      setPendingApproval(
-        pendingApprovalFromWorkflows(workflowsRes.data.workflows),
-      );
-      const vaultConsent = pendingVaultConsentFromWorkflows(
-        workflowsRes.data.workflows,
-      );
-      setPendingVaultConsentWorkflowId(vaultConsent?.id ?? null);
-    }
-  }, [sessionToken]);
+  const refreshWorkflowState = useCallback(
+    async (generation?: number) => {
+      const workflowsRes = await listWorkflows(sessionToken);
+      if (generation !== undefined && generation !== loadGeneration.current) {
+        return;
+      }
+      if (workflowsRes.ok && workflowsRes.data) {
+        setPendingApproval(
+          pendingApprovalFromWorkflows(workflowsRes.data.workflows),
+        );
+        const vaultConsent = pendingVaultConsentFromWorkflows(
+          workflowsRes.data.workflows,
+        );
+        setPendingVaultConsentWorkflowId(vaultConsent?.id ?? null);
+      }
+    },
+    [sessionToken],
+  );
 
   const load = useCallback(async () => {
     const generation = ++loadGeneration.current;
@@ -105,8 +111,9 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
     }
 
     if (generation !== loadGeneration.current) return;
-    await refreshWorkflowState();
+    await refreshWorkflowState(generation);
 
+    if (generation !== loadGeneration.current) return;
     setLoading(false);
   }, [sessionToken, refreshWorkflowState]);
 

--- a/src/components/SecureVaultCard.tsx
+++ b/src/components/SecureVaultCard.tsx
@@ -1,0 +1,310 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2, Lock, Shield } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import {
+  deleteVaultField,
+  getVaultFieldValue,
+  getVaultOverview,
+  upsertVaultField,
+  type VaultFieldMetadata,
+  type VaultOverviewSection,
+} from "@/auth/backend";
+import { VaultFieldInput } from "@/components/VaultFieldInput";
+import {
+  getVaultFieldValidationError,
+  isSensitiveVaultField,
+} from "@/lib/vault-fields";
+
+const CATEGORY_LABELS: Record<string, string> = {
+  IDENTITY: "Identity",
+  ADDRESS: "Address",
+  EMPLOYMENT: "Employment",
+  FINANCIAL: "Financial",
+};
+
+interface SecureVaultCardProps {
+  sessionToken: string;
+}
+
+export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [featureDisabled, setFeatureDisabled] = useState(false);
+  const [sections, setSections] = useState<VaultOverviewSection[]>([]);
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldToDelete, setFieldToDelete] = useState<VaultFieldMetadata | null>(
+    null,
+  );
+  const loadGeneration = useRef(0);
+
+  const load = useCallback(async () => {
+    const generation = ++loadGeneration.current;
+    setLoading(true);
+    setError(null);
+    setFeatureDisabled(false);
+
+    const res = await getVaultOverview(sessionToken);
+    if (generation !== loadGeneration.current) return;
+
+    if (!res.ok || !res.data) {
+      if (res.status === 404) {
+        setFeatureDisabled(true);
+      } else {
+        setError(res.error ?? "Could not load secure vault");
+      }
+      setLoading(false);
+      return;
+    }
+
+    setSections(res.data.sections);
+    setLoading(false);
+  }, [sessionToken]);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      loadGeneration.current += 1;
+    };
+  }, [load]);
+
+  async function startEdit(field: VaultFieldMetadata) {
+    setEditingKey(field.fieldKey);
+    setEditValue("");
+    setError(null);
+    if (field.isStored) {
+      const res = await getVaultFieldValue(sessionToken, field.fieldKey);
+      if (res.ok && res.data?.field?.value) {
+        setEditValue(res.data.field.value);
+      }
+    }
+  }
+
+  function cancelEdit() {
+    setEditingKey(null);
+    setEditValue("");
+  }
+
+  async function handleSave(field: VaultFieldMetadata) {
+    const trimmed = editValue.trim();
+    const validationError = getVaultFieldValidationError(field.fieldKey, trimmed);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await upsertVaultField(sessionToken, field.fieldKey, trimmed, true);
+      if (!res.ok) {
+        setError(res.error ?? "Failed to save field");
+        return;
+      }
+      toast({ title: `${field.label} saved securely` });
+      setEditingKey(null);
+      setEditValue("");
+      await load();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(field: VaultFieldMetadata) {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await deleteVaultField(sessionToken, field.fieldKey);
+      if (!res.ok) {
+        setError(res.error ?? "Failed to delete field");
+        return;
+      }
+      toast({ title: `${field.label} removed from vault` });
+      if (editingKey === field.fieldKey) cancelEdit();
+      setFieldToDelete(null);
+      await load();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Shield className="h-5 w-5" />
+            Secure Vault
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading…
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (featureDisabled) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Shield className="h-5 w-5" />
+          Secure Vault
+        </CardTitle>
+        <CardDescription>
+          Store sensitive details encrypted. Partner applications only access
+          vault fields after you explicitly approve each request.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {sections.map((section) => (
+          <div key={section.category} className="space-y-3">
+            <h3 className="text-sm font-medium">
+              {CATEGORY_LABELS[section.category] ?? section.category}
+            </h3>
+            <ul className="space-y-3">
+              {section.fields.map((field) => {
+                const isEditing = editingKey === field.fieldKey;
+                return (
+                  <li
+                    key={field.fieldKey}
+                    className="rounded-md border p-3 space-y-2"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <Lock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+                        <span className="font-medium text-sm">{field.label}</span>
+                      </div>
+                      {field.isStored ? (
+                        <Badge variant="secondary" className="text-[10px]">
+                          {field.maskedPreview ?? "On file"}
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-[10px]">
+                          Not stored
+                        </Badge>
+                      )}
+                    </div>
+
+                    {isEditing ? (
+                      <div className="space-y-2">
+                        <Label htmlFor={`vault-${field.fieldKey}`}>{field.label}</Label>
+                        <VaultFieldInput
+                          id={`vault-${field.fieldKey}`}
+                          inputType={field.inputType}
+                          value={editValue}
+                          onChange={setEditValue}
+                          disabled={saving}
+                          sensitive={isSensitiveVaultField(field.fieldKey)}
+                        />
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            size="sm"
+                            onClick={() => void handleSave(field)}
+                            disabled={saving}
+                          >
+                            {saving ? (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                            ) : null}
+                            Save
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={cancelEdit}
+                            disabled={saving}
+                          >
+                            Cancel
+                          </Button>
+                          {field.isStored ? (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="text-destructive"
+                              onClick={() => setFieldToDelete(field)}
+                              disabled={saving}
+                            >
+                              Remove
+                            </Button>
+                          ) : null}
+                        </div>
+                      </div>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void startEdit(field)}
+                      >
+                        {field.isStored ? "Update" : "Add"}
+                      </Button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </CardContent>
+
+      <AlertDialog
+        open={fieldToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setFieldToDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove from vault?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {fieldToDelete
+                ? `This will permanently delete ${fieldToDelete.label} from your secure vault. Partner applications will need you to enter it again.`
+                : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={saving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={saving || !fieldToDelete}
+              onClick={(event) => {
+                event.preventDefault();
+                if (fieldToDelete) void handleDelete(fieldToDelete);
+              }}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/src/components/SecureVaultCard.tsx
+++ b/src/components/SecureVaultCard.tsx
@@ -59,6 +59,7 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
     null,
   );
   const loadGeneration = useRef(0);
+  const editRequestKeyRef = useRef<string | null>(null);
 
   const load = useCallback(async () => {
     const generation = ++loadGeneration.current;
@@ -91,18 +92,26 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
   }, [load]);
 
   async function startEdit(field: VaultFieldMetadata) {
+    const requestedFieldKey = field.fieldKey;
+    editRequestKeyRef.current = requestedFieldKey;
     setEditingKey(field.fieldKey);
     setEditValue("");
     setError(null);
     if (field.isStored) {
       const res = await getVaultFieldValue(sessionToken, field.fieldKey);
-      if (res.ok && res.data?.field?.value) {
+      if (editRequestKeyRef.current !== requestedFieldKey) {
+        return;
+      }
+      if (res.ok && res.data?.field) {
         setEditValue(res.data.field.value);
+      } else {
+        setError(res.error ?? `Failed to load ${field.label}`);
       }
     }
   }
 
   function cancelEdit() {
+    editRequestKeyRef.current = null;
     setEditingKey(null);
     setEditValue("");
   }
@@ -124,6 +133,7 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
         return;
       }
       toast({ title: `${field.label} saved securely` });
+      editRequestKeyRef.current = null;
       setEditingKey(null);
       setEditValue("");
       await load();
@@ -263,6 +273,7 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
                         size="sm"
                         variant="outline"
                         onClick={() => void startEdit(field)}
+                        disabled={saving}
                       >
                         {field.isStored ? "Update" : "Add"}
                       </Button>

--- a/src/components/VaultFieldInput.tsx
+++ b/src/components/VaultFieldInput.tsx
@@ -98,16 +98,16 @@ export function VaultFieldInput({
 
   if (inputType === "ssn") {
     return (
-      <MaskedInput
+      <Input
         id={id}
+        type="password"
+        inputMode="numeric"
+        autoComplete="off"
         value={value}
-        onChange={(next) => onChange(formatSsnInput(next))}
+        onChange={(e) => onChange(formatSsnInput(e.target.value))}
         disabled={disabled}
         placeholder="###-##-####"
-        inputMode="numeric"
         maxLength={11}
-        revealLabel="Show SSN"
-        hideLabel="Hide SSN"
       />
     );
   }

--- a/src/components/VaultFieldInput.tsx
+++ b/src/components/VaultFieldInput.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Eye, EyeOff } from "lucide-react";
+import type { VaultFieldInputType } from "@/lib/vault-fields";
+import { formatSsnInput } from "@/lib/vault-fields";
+
+interface VaultFieldInputProps {
+  inputType: VaultFieldInputType;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  id?: string;
+  placeholder?: string;
+  /** Mask value with show/hide toggle (SSN always masked). */
+  sensitive?: boolean;
+}
+
+function MaskedInput({
+  id,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+  inputMode,
+  maxLength,
+  revealLabel,
+  hideLabel,
+}: {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  inputMode?: "numeric" | "decimal" | "text";
+  maxLength?: number;
+  revealLabel: string;
+  hideLabel: string;
+}) {
+  const [revealed, setRevealed] = useState(false);
+
+  return (
+    <div className="flex gap-2">
+      <Input
+        id={id}
+        type={revealed ? "text" : "password"}
+        inputMode={inputMode}
+        autoComplete="off"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder={placeholder}
+        maxLength={maxLength}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        onClick={() => setRevealed((v) => !v)}
+        disabled={disabled}
+        aria-label={revealed ? hideLabel : revealLabel}
+      >
+        {revealed ? (
+          <EyeOff className="h-4 w-4" aria-hidden />
+        ) : (
+          <Eye className="h-4 w-4" aria-hidden />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+export function VaultFieldInput({
+  inputType,
+  value,
+  onChange,
+  disabled,
+  id,
+  placeholder,
+  sensitive = false,
+}: VaultFieldInputProps) {
+  if (inputType === "address") {
+    return (
+      <Textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        placeholder={
+          placeholder ??
+          '{"line1":"...","city":"...","state":"...","postalCode":"..."}'
+        }
+        rows={3}
+      />
+    );
+  }
+
+  if (inputType === "ssn") {
+    return (
+      <MaskedInput
+        id={id}
+        value={value}
+        onChange={(next) => onChange(formatSsnInput(next))}
+        disabled={disabled}
+        placeholder="###-##-####"
+        inputMode="numeric"
+        maxLength={11}
+        revealLabel="Show SSN"
+        hideLabel="Hide SSN"
+      />
+    );
+  }
+
+  if (sensitive) {
+    return (
+      <MaskedInput
+        id={id}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        revealLabel="Show value"
+        hideLabel="Hide value"
+      />
+    );
+  }
+
+  return (
+    <Input
+      id={id}
+      type={inputType === "date" ? "date" : inputType === "number" ? "text" : "text"}
+      inputMode={inputType === "number" ? "decimal" : undefined}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      placeholder={placeholder}
+      autoComplete="off"
+    />
+  );
+}

--- a/src/components/VaultFieldInput.tsx
+++ b/src/components/VaultFieldInput.tsx
@@ -98,16 +98,16 @@ export function VaultFieldInput({
 
   if (inputType === "ssn") {
     return (
-      <Input
+      <MaskedInput
         id={id}
-        type="password"
-        inputMode="numeric"
-        autoComplete="off"
         value={value}
-        onChange={(e) => onChange(formatSsnInput(e.target.value))}
+        onChange={(v) => onChange(formatSsnInput(v))}
         disabled={disabled}
         placeholder="###-##-####"
+        inputMode="numeric"
         maxLength={11}
+        revealLabel="Show SSN"
+        hideLabel="Hide SSN"
       />
     );
   }

--- a/src/components/WorkflowMissingInputFields.tsx
+++ b/src/components/WorkflowMissingInputFields.tsx
@@ -52,8 +52,7 @@ export function WorkflowMissingInputFields({
         }
 
         if (isVaultFieldKey(key)) {
-          const vaultField = getVaultFieldDefinition(key);
-          if (!vaultField) return null;
+          const vaultField = getVaultFieldDefinition(key)!;
           return (
             <div key={key} className="space-y-2">
               <Label htmlFor={`${idPrefix}-${key}`}>{vaultField.label}</Label>

--- a/src/components/WorkflowMissingInputFields.tsx
+++ b/src/components/WorkflowMissingInputFields.tsx
@@ -72,40 +72,45 @@ export function WorkflowMissingInputFields({
         }
 
         const question = questionByKey.get(key);
+        const label =
+          question?.label ?? getVaultFieldLabel(key) ?? humanizeWorkflowKey(key);
         return (
           <div key={key} className="space-y-2">
-            <Label htmlFor={`${idPrefix}-${key}`}>
-              {question?.label ?? getVaultFieldLabel(key) ?? humanizeWorkflowKey(key)}
-            </Label>
             {question?.options?.length ? (
-              <RadioGroup
-                value={answers[key] ?? ""}
-                onValueChange={(value) => onAnswerChange(key, value)}
-                className="space-y-1.5"
-              >
-                {question.options.map((option) => (
-                  <div key={option.value} className="flex items-center gap-2">
-                    <RadioGroupItem
-                      value={option.value}
-                      id={`${idPrefix}-${key}-${option.value}`}
-                      disabled={disabled}
-                    />
-                    <Label
-                      htmlFor={`${idPrefix}-${key}-${option.value}`}
-                      className="font-normal"
-                    >
-                      {option.label}
-                    </Label>
-                  </div>
-                ))}
-              </RadioGroup>
+              <fieldset className="space-y-2">
+                <legend className="text-sm font-medium leading-none">{label}</legend>
+                <RadioGroup
+                  value={answers[key] ?? ""}
+                  onValueChange={(value) => onAnswerChange(key, value)}
+                  className="space-y-1.5"
+                >
+                  {question.options.map((option) => (
+                    <div key={option.value} className="flex items-center gap-2">
+                      <RadioGroupItem
+                        value={option.value}
+                        id={`${idPrefix}-${key}-${option.value}`}
+                        disabled={disabled}
+                      />
+                      <Label
+                        htmlFor={`${idPrefix}-${key}-${option.value}`}
+                        className="font-normal"
+                      >
+                        {option.label}
+                      </Label>
+                    </div>
+                  ))}
+                </RadioGroup>
+              </fieldset>
             ) : (
-              <Input
-                id={`${idPrefix}-${key}`}
-                value={answers[key] ?? ""}
-                onChange={(e) => onAnswerChange(key, e.target.value)}
-                disabled={disabled}
-              />
+              <>
+                <Label htmlFor={`${idPrefix}-${key}`}>{label}</Label>
+                <Input
+                  id={`${idPrefix}-${key}`}
+                  value={answers[key] ?? ""}
+                  onChange={(e) => onAnswerChange(key, e.target.value)}
+                  disabled={disabled}
+                />
+              </>
             )}
           </div>
         );

--- a/src/components/WorkflowMissingInputFields.tsx
+++ b/src/components/WorkflowMissingInputFields.tsx
@@ -52,7 +52,8 @@ export function WorkflowMissingInputFields({
         }
 
         if (isVaultFieldKey(key)) {
-          const vaultField = getVaultFieldDefinition(key)!;
+          const vaultField = getVaultFieldDefinition(key);
+          if (!vaultField) return null;
           return (
             <div key={key} className="space-y-2">
               <Label htmlFor={`${idPrefix}-${key}`}>{vaultField.label}</Label>

--- a/src/components/WorkflowMissingInputFields.tsx
+++ b/src/components/WorkflowMissingInputFields.tsx
@@ -52,7 +52,7 @@ export function WorkflowMissingInputFields({
         }
 
         if (isVaultFieldKey(key)) {
-          const vaultField = getVaultFieldDefinition(key)!;
+          const vaultField = getVaultFieldDefinition(key);
           return (
             <div key={key} className="space-y-2">
               <Label htmlFor={`${idPrefix}-${key}`}>{vaultField.label}</Label>

--- a/src/components/WorkflowMissingInputFields.tsx
+++ b/src/components/WorkflowMissingInputFields.tsx
@@ -1,0 +1,115 @@
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Input } from "@/components/ui/input";
+import type { ProfileQuestion } from "@/auth";
+import type { WorkflowQuestionDefinition } from "@/auth/backend";
+import {
+  WorkflowQuestionField,
+} from "@/components/WorkflowQuestionFields";
+import { VaultFieldInput } from "@/components/VaultFieldInput";
+import {
+  getVaultFieldDefinition,
+  getVaultFieldLabel,
+  isSensitiveVaultField,
+  isVaultFieldKey,
+} from "@/lib/vault-fields";
+import { humanizeWorkflowKey } from "@/lib/workflow-ui";
+
+interface WorkflowMissingInputFieldsProps {
+  visibleQuestionKeys: string[];
+  inputQuestions?: WorkflowQuestionDefinition[];
+  questionByKey: Map<string, ProfileQuestion>;
+  answers: Record<string, string>;
+  onAnswerChange: (key: string, value: string) => void;
+  disabled?: boolean;
+  idPrefix: string;
+}
+
+export function WorkflowMissingInputFields({
+  visibleQuestionKeys,
+  inputQuestions,
+  questionByKey,
+  answers,
+  onAnswerChange,
+  disabled,
+  idPrefix,
+}: WorkflowMissingInputFieldsProps) {
+  return (
+    <>
+      {visibleQuestionKeys.map((key) => {
+        const richQuestion = inputQuestions?.find((q) => q.key === key);
+        if (richQuestion) {
+          return (
+            <WorkflowQuestionField
+              key={key}
+              question={richQuestion}
+              value={answers[key] ?? ""}
+              onChange={(value) => onAnswerChange(key, value)}
+              disabled={disabled}
+              idPrefix={idPrefix}
+            />
+          );
+        }
+
+        if (isVaultFieldKey(key)) {
+          const vaultField = getVaultFieldDefinition(key)!;
+          return (
+            <div key={key} className="space-y-2">
+              <Label htmlFor={`${idPrefix}-${key}`}>{vaultField.label}</Label>
+              <VaultFieldInput
+                id={`${idPrefix}-${key}`}
+                inputType={vaultField.inputType}
+                value={answers[key] ?? ""}
+                onChange={(value) => onAnswerChange(key, value)}
+                disabled={disabled}
+                sensitive={isSensitiveVaultField(key)}
+              />
+              <p className="text-xs text-muted-foreground">
+                Stored encrypted in your secure vault.
+              </p>
+            </div>
+          );
+        }
+
+        const question = questionByKey.get(key);
+        return (
+          <div key={key} className="space-y-2">
+            <Label htmlFor={`${idPrefix}-${key}`}>
+              {question?.label ?? getVaultFieldLabel(key) ?? humanizeWorkflowKey(key)}
+            </Label>
+            {question?.options?.length ? (
+              <RadioGroup
+                value={answers[key] ?? ""}
+                onValueChange={(value) => onAnswerChange(key, value)}
+                className="space-y-1.5"
+              >
+                {question.options.map((option) => (
+                  <div key={option.value} className="flex items-center gap-2">
+                    <RadioGroupItem
+                      value={option.value}
+                      id={`${idPrefix}-${key}-${option.value}`}
+                      disabled={disabled}
+                    />
+                    <Label
+                      htmlFor={`${idPrefix}-${key}-${option.value}`}
+                      className="font-normal"
+                    >
+                      {option.label}
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
+            ) : (
+              <Input
+                id={`${idPrefix}-${key}`}
+                value={answers[key] ?? ""}
+                onChange={(e) => onAnswerChange(key, e.target.value)}
+                disabled={disabled}
+              />
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -137,12 +137,14 @@ export function WorkflowPerkDialog({
     };
   }, [open, workflowId, loadWorkflow, clearPoll]);
 
+  const workflowState = detail?.workflow.state;
+
   useEffect(() => {
     clearPoll();
     if (
       open &&
-      detail &&
-      AUTO_PROGRESS_WORKFLOW_STATES.includes(detail.workflow.state) &&
+      workflowState &&
+      AUTO_PROGRESS_WORKFLOW_STATES.includes(workflowState) &&
       workflowId
     ) {
       pollRef.current = setInterval(() => {
@@ -150,13 +152,13 @@ export function WorkflowPerkDialog({
       }, POLL_INTERVAL_MS);
     }
     return clearPoll;
-  }, [open, detail?.workflow.state, workflowId, loadWorkflow, clearPoll]);
+  }, [open, workflowState, workflowId, loadWorkflow, clearPoll]);
 
   useEffect(() => {
-    if (open && detail?.workflow.state === "WAITING_FOR_INPUT") {
+    if (open && workflowState === "WAITING_FOR_INPUT") {
       void loadQuestions();
     }
-  }, [open, detail?.workflow.state, loadQuestions]);
+  }, [open, workflowState, loadQuestions]);
 
   useEffect(() => {
     const keys = new Set(detail?.workflow.missingInputKeys ?? []);
@@ -175,16 +177,16 @@ export function WorkflowPerkDialog({
   }, [detail?.workflow.missingInputKeys, detail?.workflow.inputQuestions]);
 
   useEffect(() => {
-    if (!detail || settledNotified.current) return;
+    if (!workflowState || settledNotified.current) return;
     if (
-      detail.workflow.state === "COMPLETED" ||
-      detail.workflow.state === "FAILED" ||
-      detail.workflow.state === "CANCELLED"
+      workflowState === "COMPLETED" ||
+      workflowState === "FAILED" ||
+      workflowState === "CANCELLED"
     ) {
       settledNotified.current = true;
       onSettled?.();
     }
-  }, [detail?.workflow.state, onSettled]);
+  }, [workflowState, onSettled]);
 
   const questionByKey = useMemo(() => {
     const map = new Map<string, ProfileQuestion>();

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -214,7 +214,7 @@ export function WorkflowPerkDialog({
       return;
     }
     const vaultValidationError = getVaultAnswersValidationError(
-      missing,
+      visibleQuestionKeys,
       answers,
     );
     if (vaultValidationError) {

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -97,19 +97,13 @@ export function WorkflowPerkDialog({
     }
   }, []);
 
-  const load = useCallback(
+  const loadWorkflow = useCallback(
     async (id: string) => {
-      const [workflowRes, profileRes] = await Promise.all([
-        getWorkflow(sessionToken, id),
-        getUserProfileInformation(sessionToken),
-      ]);
+      const workflowRes = await getWorkflow(sessionToken, id);
       if (!workflowRes.ok || !workflowRes.data) {
         setError(workflowRes.error ?? "Failed to load application");
         setLoading(false);
         return;
-      }
-      if (profileRes.success) {
-        setQuestions(profileRes.questions);
       }
       setDetail({
         workflow: workflowRes.data.workflow,
@@ -124,17 +118,24 @@ export function WorkflowPerkDialog({
     [sessionToken, clearPoll],
   );
 
+  const loadQuestions = useCallback(async () => {
+    const profileRes = await getUserProfileInformation(sessionToken);
+    if (profileRes.success) {
+      setQuestions(profileRes.questions);
+    }
+  }, [sessionToken]);
+
   useEffect(() => {
     if (!open || !workflowId) return;
     settledNotified.current = false;
     setLoading(true);
     setDetail(null);
     setAnswers({});
-    void load(workflowId);
+    void loadWorkflow(workflowId);
     return () => {
       clearPoll();
     };
-  }, [open, workflowId, load, clearPoll]);
+  }, [open, workflowId, loadWorkflow, clearPoll]);
 
   useEffect(() => {
     clearPoll();
@@ -145,11 +146,17 @@ export function WorkflowPerkDialog({
       workflowId
     ) {
       pollRef.current = setInterval(() => {
-        void load(workflowId);
+        void loadWorkflow(workflowId);
       }, POLL_INTERVAL_MS);
     }
     return clearPoll;
-  }, [open, detail?.workflow.state, workflowId, load, clearPoll]);
+  }, [open, detail?.workflow.state, workflowId, loadWorkflow, clearPoll]);
+
+  useEffect(() => {
+    if (open && detail?.workflow.state === "WAITING_FOR_INPUT") {
+      void loadQuestions();
+    }
+  }, [open, detail?.workflow.state, loadQuestions]);
 
   useEffect(() => {
     const keys = new Set(detail?.workflow.missingInputKeys ?? []);
@@ -205,7 +212,7 @@ export function WorkflowPerkDialog({
       return;
     }
     const vaultValidationError = getVaultAnswersValidationError(
-      visibleQuestionKeys,
+      missing,
       answers,
     );
     if (vaultValidationError) {

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -10,8 +10,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import {
   approveWorkflowStep,
@@ -19,31 +17,19 @@ import {
   getWorkflow,
   submitWorkflowInputs,
   type WorkflowDetailResult,
-  type WorkflowState,
-  type WorkflowStepRunData,
 } from "@/auth/backend";
+import { getUserProfileInformation, type ProfileQuestion } from "@/auth";
+import { getVisibleWorkflowQuestionKeys } from "@/components/WorkflowQuestionFields";
+import { getVaultAnswersValidationError } from "@/lib/vault-fields";
+import { WorkflowMissingInputFields } from "@/components/WorkflowMissingInputFields";
+import { WorkflowVaultConsentPanel } from "@/components/WorkflowVaultConsentPanel";
 import {
-  WorkflowQuestionField,
-  getVisibleWorkflowQuestionKeys,
-} from "@/components/WorkflowQuestionFields";
-import { humanizeWorkflowKey } from "@/lib/workflow-ui";
+  AUTO_PROGRESS_WORKFLOW_STATES,
+  CANCELLABLE_WORKFLOW_STATES,
+  workflowStateBadge,
+} from "@/lib/workflow-ui";
 import { useToast } from "@/hooks/use-toast";
 import { trackPerksEvent } from "@/lib/product-analytics";
-
-/** States that progress on their own (via cron/engine) — worth polling for updates.
- * Mirrors WorkflowsCard.tsx AUTO_PROGRESS_STATES. */
-const AUTO_PROGRESS_STATES: WorkflowState[] = [
-  "CREATED",
-  "READY_TO_EXECUTE",
-  "EXECUTING",
-];
-
-const CANCELLABLE_STATES: WorkflowState[] = [
-  "CREATED",
-  "WAITING_FOR_INPUT",
-  "READY_TO_EXECUTE",
-  "WAITING_FOR_APPROVAL",
-];
 
 const POLL_INTERVAL_MS = 4000;
 
@@ -54,26 +40,7 @@ function humanize(key: string): string {
     .join(" ");
 }
 
-function stateBadge(
-  state: WorkflowState,
-): { label: string; variant: "default" | "secondary" | "destructive" | "outline" } {
-  switch (state) {
-    case "COMPLETED":
-      return { label: "Completed", variant: "default" };
-    case "FAILED":
-      return { label: "Failed", variant: "destructive" };
-    case "CANCELLED":
-      return { label: "Cancelled", variant: "outline" };
-    case "WAITING_FOR_INPUT":
-      return { label: "Needs info", variant: "secondary" };
-    case "WAITING_FOR_APPROVAL":
-      return { label: "Needs approval", variant: "secondary" };
-    default:
-      return { label: "In progress", variant: "secondary" };
-  }
-}
-
-function stepIcon(step: WorkflowStepRunData) {
+function stepIcon(step: { status: string }) {
   if (step.status === "COMPLETED") {
     return <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden />;
   }
@@ -102,12 +69,9 @@ interface WorkflowPerkDialogProps {
   workflowId: string | null;
   perkTitle: string;
   onOpenChange: (open: boolean) => void;
-  /** Called after the workflow completes/is cancelled so the Perks list can refresh. */
   onSettled?: () => void;
 }
 
-/** Renders a Chase-style VIG questionnaire + step tracker as a dialog on the Perks page,
- * reusing the same field/step rendering as the account-dashboard WorkflowsCard. */
 export function WorkflowPerkDialog({
   open,
   sessionToken,
@@ -120,6 +84,7 @@ export function WorkflowPerkDialog({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [detail, setDetail] = useState<WorkflowDetailResult | null>(null);
+  const [questions, setQuestions] = useState<ProfileQuestion[]>([]);
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -134,16 +99,25 @@ export function WorkflowPerkDialog({
 
   const load = useCallback(
     async (id: string) => {
-      const res = await getWorkflow(sessionToken, id);
-      if (!res.ok || !res.data) {
-        setError(res.error ?? "Failed to load application");
+      const [workflowRes, profileRes] = await Promise.all([
+        getWorkflow(sessionToken, id),
+        getUserProfileInformation(sessionToken),
+      ]);
+      if (!workflowRes.ok || !workflowRes.data) {
+        setError(workflowRes.error ?? "Failed to load application");
         setLoading(false);
         return;
       }
-      setDetail({ workflow: res.data.workflow, steps: res.data.steps });
+      if (profileRes.success) {
+        setQuestions(profileRes.questions);
+      }
+      setDetail({
+        workflow: workflowRes.data.workflow,
+        steps: workflowRes.data.steps,
+      });
       setError(null);
       setLoading(false);
-      if (!AUTO_PROGRESS_STATES.includes(res.data.workflow.state)) {
+      if (!AUTO_PROGRESS_WORKFLOW_STATES.includes(workflowRes.data.workflow.state)) {
         clearPoll();
       }
     },
@@ -167,7 +141,7 @@ export function WorkflowPerkDialog({
     if (
       open &&
       detail &&
-      AUTO_PROGRESS_STATES.includes(detail.workflow.state) &&
+      AUTO_PROGRESS_WORKFLOW_STATES.includes(detail.workflow.state) &&
       workflowId
     ) {
       pollRef.current = setInterval(() => {
@@ -203,8 +177,13 @@ export function WorkflowPerkDialog({
       settledNotified.current = true;
       onSettled?.();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [detail?.workflow.state]);
+  }, [detail?.workflow.state, onSettled]);
+
+  const questionByKey = useMemo(() => {
+    const map = new Map<string, ProfileQuestion>();
+    for (const question of questions) map.set(question.key, question);
+    return map;
+  }, [questions]);
 
   const visibleQuestionKeys = useMemo(() => {
     if (!detail) return [];
@@ -223,6 +202,14 @@ export function WorkflowPerkDialog({
     );
     if (missingUnanswered.length > 0) {
       setError("Please answer all questions above before continuing.");
+      return;
+    }
+    const vaultValidationError = getVaultAnswersValidationError(
+      visibleQuestionKeys,
+      answers,
+    );
+    if (vaultValidationError) {
+      setError(vaultValidationError);
       return;
     }
     const sanitized = Object.fromEntries(
@@ -290,7 +277,7 @@ export function WorkflowPerkDialog({
   }
 
   const workflow = detail?.workflow;
-  const badge = workflow ? stateBadge(workflow.state) : null;
+  const badge = workflow ? workflowStateBadge(workflow.state) : null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -356,48 +343,34 @@ export function WorkflowPerkDialog({
               </ul>
             ) : null}
 
+            {workflow.state === "WAITING_FOR_VAULT_CONSENT" && workflowId && (
+              <WorkflowVaultConsentPanel
+                sessionToken={sessionToken}
+                workflowId={workflowId}
+                submitting={submitting}
+                setSubmitting={setSubmitting}
+                onUpdated={(updated) => setDetail(updated)}
+                showCancel
+                onCancel={() => void handleCancel()}
+              />
+            )}
+
             {workflow.state === "WAITING_FOR_INPUT" && (
               <div className="space-y-4 rounded-md bg-muted/40 p-3">
                 <p className="text-sm font-medium">
                   We need a bit more information to continue.
                 </p>
-                {visibleQuestionKeys.map((key) => {
-                  const question = workflow.inputQuestions?.find(
-                    (q) => q.key === key,
-                  );
-                  if (question) {
-                    return (
-                      <WorkflowQuestionField
-                        key={key}
-                        question={question}
-                        value={answers[key] ?? ""}
-                        onChange={(value) =>
-                          setAnswers((current) => ({ ...current, [key]: value }))
-                        }
-                        disabled={submitting}
-                        idPrefix="perk-workflow"
-                      />
-                    );
+                <WorkflowMissingInputFields
+                  visibleQuestionKeys={visibleQuestionKeys}
+                  inputQuestions={workflow.inputQuestions}
+                  questionByKey={questionByKey}
+                  answers={answers}
+                  onAnswerChange={(key, value) =>
+                    setAnswers((current) => ({ ...current, [key]: value }))
                   }
-                  return (
-                    <div key={key} className="space-y-2">
-                      <Label htmlFor={`perk-workflow-${key}`}>
-                        {humanizeWorkflowKey(key)}
-                      </Label>
-                      <Input
-                        id={`perk-workflow-${key}`}
-                        value={answers[key] ?? ""}
-                        onChange={(e) =>
-                          setAnswers((current) => ({
-                            ...current,
-                            [key]: e.target.value,
-                          }))
-                        }
-                        disabled={submitting}
-                      />
-                    </div>
-                  );
-                })}
+                  disabled={submitting}
+                  idPrefix="perk-workflow"
+                />
                 <Button
                   size="sm"
                   onClick={() => void handleSubmitInputs()}
@@ -489,8 +462,9 @@ export function WorkflowPerkDialog({
 
         <DialogFooter>
           {workflow &&
-          CANCELLABLE_STATES.includes(workflow.state) &&
-          workflow.state !== "WAITING_FOR_APPROVAL" ? (
+          CANCELLABLE_WORKFLOW_STATES.includes(workflow.state) &&
+          workflow.state !== "WAITING_FOR_APPROVAL" &&
+          workflow.state !== "WAITING_FOR_VAULT_CONSENT" ? (
             <Button
               variant="ghost"
               className="text-muted-foreground"

--- a/src/components/WorkflowVaultConsentPanel.tsx
+++ b/src/components/WorkflowVaultConsentPanel.tsx
@@ -115,16 +115,14 @@ export function WorkflowVaultConsentPanel({
           </a>{" "}
           and refresh this page.
         </p>
-        {error ? (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={() => void load()}
-            disabled={submitting}
-          >
-            Try again
-          </Button>
-        ) : null}
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => void load()}
+          disabled={submitting}
+        >
+          {error ? "Try again" : "Check again"}
+        </Button>
       </div>
     );
   }

--- a/src/components/WorkflowVaultConsentPanel.tsx
+++ b/src/components/WorkflowVaultConsentPanel.tsx
@@ -44,11 +44,11 @@ export function WorkflowVaultConsentPanel({
     setLoading(true);
     setError(null);
     const res = await getWorkflowVaultAccess(sessionToken, workflowId);
-    if (!res.ok || !res.data?.request) {
+    if (!res.ok) {
       setRequest(null);
       setError(res.error ?? "Could not load vault access request");
     } else {
-      setRequest(res.data.request);
+      setRequest(res.data?.request ?? null);
     }
     setLoading(false);
   }, [sessionToken, workflowId]);
@@ -101,9 +101,13 @@ export function WorkflowVaultConsentPanel({
   if (!request) {
     return (
       <div className="space-y-3 rounded-md bg-muted/40 p-3">
-        <p className="text-sm text-destructive">
-          {error ?? "No pending vault access request was found."}
-        </p>
+        {error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No pending vault access request was found.
+          </p>
+        )}
         <p className="text-sm text-muted-foreground">
           If you haven&apos;t stored the required details yet, add them in your{" "}
           <a href="#vault" className="font-medium underline">
@@ -111,9 +115,16 @@ export function WorkflowVaultConsentPanel({
           </a>{" "}
           and refresh this page.
         </p>
-        <Button size="sm" variant="outline" onClick={() => void load()} disabled={submitting}>
-          Try again
-        </Button>
+        {error ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void load()}
+            disabled={submitting}
+          >
+            Try again
+          </Button>
+        ) : null}
       </div>
     );
   }

--- a/src/components/WorkflowVaultConsentPanel.tsx
+++ b/src/components/WorkflowVaultConsentPanel.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Loader2, Shield } from "lucide-react";
+import {
+  approveWorkflowVaultAccess,
+  denyWorkflowVaultAccess,
+  getWorkflowVaultAccess,
+  type VaultAccessRequestInfo,
+  type WorkflowDetailResult,
+} from "@/auth/backend";
+import { notifyWorkflowsUpdated } from "@/lib/workflow-events";
+
+interface WorkflowVaultConsentPanelProps {
+  sessionToken: string;
+  workflowId: string;
+  onUpdated: (detail: WorkflowDetailResult) => void;
+  submitting: boolean;
+  setSubmitting: (value: boolean) => void;
+  showCancel?: boolean;
+  onCancel?: () => void;
+}
+
+function formatExpiry(expiresAt: string): string {
+  return new Date(expiresAt).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function WorkflowVaultConsentPanel({
+  sessionToken,
+  workflowId,
+  onUpdated,
+  submitting,
+  setSubmitting,
+  showCancel,
+  onCancel,
+}: WorkflowVaultConsentPanelProps) {
+  const [loading, setLoading] = useState(true);
+  const [request, setRequest] = useState<VaultAccessRequestInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await getWorkflowVaultAccess(sessionToken, workflowId);
+    if (!res.ok || !res.data?.request) {
+      setRequest(null);
+      setError(res.error ?? "Could not load vault access request");
+    } else {
+      setRequest(res.data.request);
+    }
+    setLoading(false);
+  }, [sessionToken, workflowId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleApprove() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await approveWorkflowVaultAccess(sessionToken, workflowId);
+      if (!res.ok || !res.data) {
+        setError(res.error ?? "Failed to approve vault access");
+        return;
+      }
+      onUpdated({ workflow: res.data.workflow, steps: res.data.steps });
+      notifyWorkflowsUpdated();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleDeny() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await denyWorkflowVaultAccess(sessionToken, workflowId);
+      if (!res.ok || !res.data) {
+        setError(res.error ?? "Failed to deny vault access");
+        return;
+      }
+      onUpdated({ workflow: res.data.workflow, steps: res.data.steps });
+      notifyWorkflowsUpdated();
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+        Loading vault access request…
+      </div>
+    );
+  }
+
+  if (!request) {
+    return (
+      <div className="space-y-3 rounded-md bg-muted/40 p-3">
+        <p className="text-sm text-destructive">
+          {error ?? "No pending vault access request was found."}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          If you haven&apos;t stored the required details yet, add them in your{" "}
+          <a href="#vault" className="font-medium underline">
+            Secure Vault
+          </a>{" "}
+          and refresh this page.
+        </p>
+        <Button size="sm" variant="outline" onClick={() => void load()} disabled={submitting}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-md bg-muted/40 p-3">
+      <div className="flex items-start gap-2">
+        <Shield className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">
+            This application needs access to information in your secure vault
+          </p>
+          <p className="text-sm text-muted-foreground">
+            We found the required details already stored. Approve access so this
+            workflow can use them — nothing is shared with the partner until you
+            approve the final submission step.
+          </p>
+        </div>
+      </div>
+      <ul className="list-disc space-y-1 pl-5 text-sm">
+        {request.fields.map((field) => (
+          <li key={field.fieldKey}>{field.label}</li>
+        ))}
+      </ul>
+      {request.expiresAt ? (
+        <p className="text-xs text-muted-foreground">
+          This request expires {formatExpiry(request.expiresAt)}.
+        </p>
+      ) : null}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <div className="flex flex-wrap gap-2">
+        <Button size="sm" onClick={() => void handleApprove()} disabled={submitting}>
+          {submitting ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+          ) : null}
+          Allow access
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => void handleDeny()}
+          disabled={submitting}
+        >
+          Deny
+        </Button>
+        {showCancel && onCancel ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-muted-foreground"
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Cancel application
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -219,7 +219,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
       return;
     }
     const vaultValidationError = getVaultAnswersValidationError(
-      visibleQuestionKeys,
+      missing,
       answers,
     );
     if (vaultValidationError) {

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -10,9 +10,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Input } from "@/components/ui/input";
 import {
   CheckCircle2,
   ChevronDown,
@@ -29,35 +26,23 @@ import {
   listWorkflows,
   submitWorkflowInputs,
   type WorkflowDetailResult,
-  type WorkflowState,
-  type WorkflowStepRunData,
   type WorkflowSummary,
 } from "@/auth/backend";
 import { getUserProfileInformation, type ProfileQuestion } from "@/auth";
+import { getVisibleWorkflowQuestionKeys } from "@/components/WorkflowQuestionFields";
+import { getVaultAnswersValidationError } from "@/lib/vault-fields";
+import { WorkflowMissingInputFields } from "@/components/WorkflowMissingInputFields";
+import { WorkflowVaultConsentPanel } from "@/components/WorkflowVaultConsentPanel";
 import {
-  WorkflowQuestionField,
-  getVisibleWorkflowQuestionKeys,
-} from "@/components/WorkflowQuestionFields";
-import { selectPrimaryActiveWorkflow } from "@/lib/workflow-ui";
+  AUTO_PROGRESS_WORKFLOW_STATES,
+  CANCELLABLE_WORKFLOW_STATES,
+  selectPrimaryActiveWorkflow,
+  workflowStateBadge,
+} from "@/lib/workflow-ui";
 
 interface WorkflowsCardProps {
   sessionToken: string;
 }
-
-const AUTO_PROGRESS_STATES: WorkflowState[] = [
-  "CREATED",
-  "READY_TO_EXECUTE",
-  "EXECUTING",
-];
-
-/** Mirrors backend workflow-state.util.ts isCancellableState — EXECUTING is intentionally
- * excluded since a step run may already be in flight when the cancel request arrives. */
-const CANCELLABLE_STATES: WorkflowState[] = [
-  "CREATED",
-  "WAITING_FOR_INPUT",
-  "READY_TO_EXECUTE",
-  "WAITING_FOR_APPROVAL",
-];
 
 const POLL_INTERVAL_MS = 4000;
 
@@ -68,24 +53,7 @@ function humanize(key: string): string {
     .join(" ");
 }
 
-function stateBadge(state: WorkflowState): { label: string; variant: "default" | "secondary" | "destructive" | "outline" } {
-  switch (state) {
-    case "COMPLETED":
-      return { label: "Completed", variant: "default" };
-    case "FAILED":
-      return { label: "Failed", variant: "destructive" };
-    case "CANCELLED":
-      return { label: "Cancelled", variant: "outline" };
-    case "WAITING_FOR_INPUT":
-      return { label: "Needs info", variant: "secondary" };
-    case "WAITING_FOR_APPROVAL":
-      return { label: "Needs approval", variant: "secondary" };
-    default:
-      return { label: "In progress", variant: "secondary" };
-  }
-}
-
-function stepIcon(step: WorkflowStepRunData) {
+function stepIcon(step: { status: string }) {
   if (step.status === "COMPLETED") {
     return <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden />;
   }
@@ -142,7 +110,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
         return;
       }
       setActive({ workflow: res.data.workflow, steps: res.data.steps });
-      if (!AUTO_PROGRESS_STATES.includes(res.data.workflow.state)) {
+      if (!AUTO_PROGRESS_WORKFLOW_STATES.includes(res.data.workflow.state)) {
         clearPoll();
       }
     },
@@ -197,7 +165,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
 
   useEffect(() => {
     clearPoll();
-    if (active && AUTO_PROGRESS_STATES.includes(active.workflow.state)) {
+    if (active && AUTO_PROGRESS_WORKFLOW_STATES.includes(active.workflow.state)) {
       pollRef.current = setInterval(() => {
         void loadActive(active.workflow.id);
       }, POLL_INTERVAL_MS);
@@ -248,6 +216,14 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
     );
     if (missingUnanswered.length > 0) {
       setError("Please answer all questions above before continuing.");
+      return;
+    }
+    const vaultValidationError = getVaultAnswersValidationError(
+      visibleQuestionKeys,
+      answers,
+    );
+    if (vaultValidationError) {
+      setError(vaultValidationError);
       return;
     }
     const sanitized = Object.fromEntries(
@@ -327,7 +303,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
     return null;
   }
 
-  const badge = active ? stateBadge(active.workflow.state) : null;
+  const badge = active ? workflowStateBadge(active.workflow.state) : null;
 
   return (
     <Card>
@@ -400,66 +376,34 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
               ))}
             </ul>
 
+            {active.workflow.state === "WAITING_FOR_VAULT_CONSENT" && (
+              <WorkflowVaultConsentPanel
+                sessionToken={sessionToken}
+                workflowId={active.workflow.id}
+                submitting={submitting}
+                setSubmitting={setSubmitting}
+                onUpdated={(detail) => setActive(detail)}
+                showCancel
+                onCancel={() => void handleCancel()}
+              />
+            )}
+
             {active.workflow.state === "WAITING_FOR_INPUT" && (
               <div className="space-y-4 rounded-md bg-muted/40 p-3">
                 <p className="text-sm font-medium">
                   We need a bit more information to continue.
                 </p>
-                {visibleQuestionKeys.map((key) => {
-                  const richQuestion = active.workflow.inputQuestions?.find(
-                    (q) => q.key === key,
-                  );
-                  if (richQuestion) {
-                    return (
-                      <WorkflowQuestionField
-                        key={key}
-                        question={richQuestion}
-                        value={answers[key] ?? ""}
-                        onChange={(value) =>
-                          setAnswers((current) => ({ ...current, [key]: value }))
-                        }
-                        disabled={submitting}
-                        idPrefix="workflows-card"
-                      />
-                    );
+                <WorkflowMissingInputFields
+                  visibleQuestionKeys={visibleQuestionKeys}
+                  inputQuestions={active.workflow.inputQuestions}
+                  questionByKey={questionByKey}
+                  answers={answers}
+                  onAnswerChange={(key, value) =>
+                    setAnswers((current) => ({ ...current, [key]: value }))
                   }
-                  const question = questionByKey.get(key);
-                  return (
-                    <div key={key} className="space-y-2">
-                      <Label>{question?.label ?? humanize(key)}</Label>
-                      {question?.options?.length ? (
-                        <RadioGroup
-                          value={answers[key] ?? ""}
-                          onValueChange={(value) =>
-                            setAnswers((current) => ({ ...current, [key]: value }))
-                          }
-                          className="space-y-1.5"
-                        >
-                          {question.options.map((option) => (
-                            <div key={option.value} className="flex items-center gap-2">
-                              <RadioGroupItem
-                                value={option.value}
-                                id={`${key}-${option.value}`}
-                                disabled={submitting}
-                              />
-                              <Label htmlFor={`${key}-${option.value}`} className="font-normal">
-                                {option.label}
-                              </Label>
-                            </div>
-                          ))}
-                        </RadioGroup>
-                      ) : (
-                        <Input
-                          value={answers[key] ?? ""}
-                          onChange={(e) =>
-                            setAnswers((current) => ({ ...current, [key]: e.target.value }))
-                          }
-                          disabled={submitting}
-                        />
-                      )}
-                    </div>
-                  );
-                })}
+                  disabled={submitting}
+                  idPrefix="workflows-card"
+                />
                 <Button
                   size="sm"
                   onClick={() => void handleSubmitInputs()}
@@ -536,7 +480,8 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
             )}
 
             {active.workflow.state !== "WAITING_FOR_APPROVAL" &&
-              CANCELLABLE_STATES.includes(active.workflow.state) && (
+              active.workflow.state !== "WAITING_FOR_VAULT_CONSENT" &&
+              CANCELLABLE_WORKFLOW_STATES.includes(active.workflow.state) && (
                 <Button
                   size="sm"
                   variant="ghost"
@@ -572,7 +517,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
             {showHistory && (
               <ul className="mt-2 divide-y rounded-md border">
                 {history.map((workflow) => {
-                  const historyBadge = stateBadge(workflow.state);
+                  const historyBadge = workflowStateBadge(workflow.state);
                   return (
                     <li
                       key={workflow.id}

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -219,7 +219,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
       return;
     }
     const vaultValidationError = getVaultAnswersValidationError(
-      missing,
+      visibleQuestionKeys,
       answers,
     );
     if (vaultValidationError) {

--- a/src/lib/vault-fields.ts
+++ b/src/lib/vault-fields.ts
@@ -222,7 +222,9 @@ export function getVaultAnswersValidationError(
 ): string | null {
   for (const key of keys) {
     if (!isVaultFieldKey(key)) continue;
-    const error = getVaultFieldValidationError(key, answers[key] ?? "");
+    const value = (answers[key] ?? "").trim();
+    if (!value) continue;
+    const error = getVaultFieldValidationError(key, value);
     if (error) {
       const label = getVaultFieldLabel(key);
       return `${label}: ${error}`;

--- a/src/lib/vault-fields.ts
+++ b/src/lib/vault-fields.ts
@@ -117,6 +117,8 @@ export function isVaultFieldKey(key: string): key is VaultFieldKey {
   return FIELD_BY_KEY.has(key as VaultFieldKey);
 }
 
+export function getVaultFieldDefinition(key: VaultFieldKey): VaultFieldDefinition;
+export function getVaultFieldDefinition(key: string): VaultFieldDefinition | undefined;
 export function getVaultFieldDefinition(key: string): VaultFieldDefinition | undefined {
   return FIELD_BY_KEY.get(key as VaultFieldKey);
 }

--- a/src/lib/vault-fields.ts
+++ b/src/lib/vault-fields.ts
@@ -1,0 +1,232 @@
+/** Mirrors backend vault-field.constants.ts — labels and input types for secure vault fields. */
+
+export type VaultFieldKey =
+  | "legal_full_name"
+  | "date_of_birth"
+  | "ssn"
+  | "passport_number"
+  | "drivers_license_number"
+  | "home_address"
+  | "mailing_address"
+  | "employer_name"
+  | "annual_income"
+  | "occupation"
+  | "bank_account_number"
+  | "tax_id";
+
+export type VaultFieldInputType =
+  | "text"
+  | "date"
+  | "ssn"
+  | "address"
+  | "number";
+
+export type VaultFieldCategory =
+  | "IDENTITY"
+  | "ADDRESS"
+  | "EMPLOYMENT"
+  | "FINANCIAL";
+
+export interface VaultFieldDefinition {
+  key: VaultFieldKey;
+  category: VaultFieldCategory;
+  label: string;
+  inputType: VaultFieldInputType;
+}
+
+export const VAULT_FIELD_DEFINITIONS: VaultFieldDefinition[] = [
+  {
+    key: "legal_full_name",
+    category: "IDENTITY",
+    label: "Full Name",
+    inputType: "text",
+  },
+  {
+    key: "date_of_birth",
+    category: "IDENTITY",
+    label: "Date of Birth",
+    inputType: "date",
+  },
+  {
+    key: "ssn",
+    category: "IDENTITY",
+    label: "Social Security Number",
+    inputType: "ssn",
+  },
+  {
+    key: "passport_number",
+    category: "IDENTITY",
+    label: "Passport Number",
+    inputType: "text",
+  },
+  {
+    key: "drivers_license_number",
+    category: "IDENTITY",
+    label: "Driver's License Number",
+    inputType: "text",
+  },
+  {
+    key: "home_address",
+    category: "ADDRESS",
+    label: "Home Address",
+    inputType: "address",
+  },
+  {
+    key: "mailing_address",
+    category: "ADDRESS",
+    label: "Mailing Address",
+    inputType: "address",
+  },
+  {
+    key: "employer_name",
+    category: "EMPLOYMENT",
+    label: "Employer",
+    inputType: "text",
+  },
+  {
+    key: "annual_income",
+    category: "EMPLOYMENT",
+    label: "Annual Income",
+    inputType: "number",
+  },
+  {
+    key: "occupation",
+    category: "EMPLOYMENT",
+    label: "Occupation",
+    inputType: "text",
+  },
+  {
+    key: "bank_account_number",
+    category: "FINANCIAL",
+    label: "Bank Account Number",
+    inputType: "text",
+  },
+  {
+    key: "tax_id",
+    category: "FINANCIAL",
+    label: "Tax ID",
+    inputType: "text",
+  },
+];
+
+const FIELD_BY_KEY = new Map(
+  VAULT_FIELD_DEFINITIONS.map((field) => [field.key, field]),
+);
+
+export function isVaultFieldKey(key: string): key is VaultFieldKey {
+  return FIELD_BY_KEY.has(key as VaultFieldKey);
+}
+
+export function getVaultFieldDefinition(key: string): VaultFieldDefinition | undefined {
+  return FIELD_BY_KEY.get(key as VaultFieldKey);
+}
+
+export function getVaultFieldLabel(key: string): string {
+  return getVaultFieldDefinition(key)?.label ?? key;
+}
+
+const SSN_PATTERN = /^\d{3}-\d{2}-\d{4}$/;
+
+export function formatSsnInput(raw: string): string {
+  const digits = raw.replace(/\D/g, "").slice(0, 9);
+  if (digits.length <= 3) return digits;
+  if (digits.length <= 5) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  return `${digits.slice(0, 3)}-${digits.slice(3, 5)}-${digits.slice(5)}`;
+}
+
+export function isValidSsn(value: string): boolean {
+  return SSN_PATTERN.test(value.trim());
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MAX_VAULT_FIELD_VALUE_LENGTH = 4096;
+
+const SENSITIVE_VAULT_FIELD_KEYS = new Set<VaultFieldKey>([
+  "passport_number",
+  "drivers_license_number",
+  "bank_account_number",
+  "tax_id",
+]);
+
+export function isSensitiveVaultField(key: string): boolean {
+  return (
+    key === "ssn" || SENSITIVE_VAULT_FIELD_KEYS.has(key as VaultFieldKey)
+  );
+}
+
+/** Mirrors backend validateVaultFieldValue — returns an error message or null. */
+export function getVaultFieldValidationError(
+  fieldKey: string,
+  value: string,
+): string | null {
+  if (!isVaultFieldKey(fieldKey)) return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return "Value is required";
+  if (trimmed.length > MAX_VAULT_FIELD_VALUE_LENGTH) {
+    return "Value exceeds maximum allowed length";
+  }
+
+  switch (fieldKey) {
+    case "ssn":
+      if (!SSN_PATTERN.test(trimmed)) {
+        return "SSN must be in ###-##-#### format";
+      }
+      break;
+    case "date_of_birth":
+      if (!ISO_DATE_PATTERN.test(trimmed)) {
+        return "Date of birth must be in YYYY-MM-DD format";
+      }
+      break;
+    case "annual_income":
+      if (!/^\d+(\.\d{1,2})?$/.test(trimmed)) {
+        return "Annual income must be a valid number";
+      }
+      break;
+    case "home_address":
+    case "mailing_address":
+      try {
+        const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+        if (typeof parsed.line1 !== "string" || !parsed.line1.trim()) {
+          return "Address line1 is required";
+        }
+        if (typeof parsed.city !== "string" || !parsed.city.trim()) {
+          return "Address city is required";
+        }
+        if (typeof parsed.state !== "string" || !parsed.state.trim()) {
+          return "Address state is required";
+        }
+        if (
+          typeof parsed.postalCode !== "string" ||
+          !parsed.postalCode.trim()
+        ) {
+          return "Address postalCode is required";
+        }
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          return "Address must be valid JSON";
+        }
+        return error instanceof Error ? error.message : "Invalid address";
+      }
+      break;
+    default:
+      break;
+  }
+
+  return null;
+}
+
+export function getVaultAnswersValidationError(
+  keys: string[],
+  answers: Record<string, string>,
+): string | null {
+  for (const key of keys) {
+    if (!isVaultFieldKey(key)) continue;
+    const error = getVaultFieldValidationError(key, answers[key] ?? "");
+    if (error) {
+      const label = getVaultFieldLabel(key);
+      return `${label}: ${error}`;
+    }
+  }
+  return null;
+}

--- a/src/lib/workflow-events.ts
+++ b/src/lib/workflow-events.ts
@@ -1,0 +1,6 @@
+/** Cross-component signal when workflow state may have changed (e.g. vault consent). */
+export const WORKFLOW_UPDATED_EVENT = "keen:workflows-updated";
+
+export function notifyWorkflowsUpdated(): void {
+  window.dispatchEvent(new CustomEvent(WORKFLOW_UPDATED_EVENT));
+}

--- a/src/lib/workflow-ui.ts
+++ b/src/lib/workflow-ui.ts
@@ -8,18 +8,64 @@ import type {
 export const ACTIVE_WORKFLOW_STATES: WorkflowState[] = [
   "CREATED",
   "WAITING_FOR_INPUT",
+  "WAITING_FOR_VAULT_CONSENT",
   "READY_TO_EXECUTE",
   "EXECUTING",
   "WAITING_FOR_APPROVAL",
 ];
 
+/** States the engine advances without user input — poll for updates. */
+export const AUTO_PROGRESS_WORKFLOW_STATES: WorkflowState[] = [
+  "CREATED",
+  "READY_TO_EXECUTE",
+  "EXECUTING",
+];
+
+/** Mirrors backend workflow-state.util.ts isCancellableState. */
+export const CANCELLABLE_WORKFLOW_STATES: WorkflowState[] = [
+  "CREATED",
+  "WAITING_FOR_INPUT",
+  "WAITING_FOR_VAULT_CONSENT",
+  "READY_TO_EXECUTE",
+  "WAITING_FOR_APPROVAL",
+];
+
 const ACTIVE_STATE_PRIORITY: Partial<Record<WorkflowState, number>> = {
-  WAITING_FOR_APPROVAL: 0,
-  WAITING_FOR_INPUT: 1,
-  EXECUTING: 2,
-  READY_TO_EXECUTE: 3,
-  CREATED: 4,
+  WAITING_FOR_VAULT_CONSENT: 0,
+  WAITING_FOR_APPROVAL: 1,
+  WAITING_FOR_INPUT: 2,
+  EXECUTING: 3,
+  READY_TO_EXECUTE: 4,
+  CREATED: 5,
 };
+
+export type WorkflowBadgeVariant =
+  | "default"
+  | "secondary"
+  | "destructive"
+  | "outline";
+
+export function workflowStateBadge(state: WorkflowState): {
+  label: string;
+  variant: WorkflowBadgeVariant;
+} {
+  switch (state) {
+    case "COMPLETED":
+      return { label: "Completed", variant: "default" };
+    case "FAILED":
+      return { label: "Failed", variant: "destructive" };
+    case "CANCELLED":
+      return { label: "Cancelled", variant: "outline" };
+    case "WAITING_FOR_INPUT":
+      return { label: "Needs info", variant: "secondary" };
+    case "WAITING_FOR_VAULT_CONSENT":
+      return { label: "Vault access needed", variant: "secondary" };
+    case "WAITING_FOR_APPROVAL":
+      return { label: "Needs approval", variant: "secondary" };
+    default:
+      return { label: "In progress", variant: "secondary" };
+  }
+}
 
 /** Prefer workflows that need user action, then the most recently updated run. */
 export function selectPrimaryActiveWorkflow(
@@ -50,6 +96,16 @@ export function pendingApprovalFromWorkflows(
     workflowId: waiting.id,
     stepKey: waiting.currentStepKey,
   };
+}
+
+export function pendingVaultConsentFromWorkflows(
+  workflows: WorkflowSummary[],
+): WorkflowSummary | null {
+  return (
+    workflows.find(
+      (workflow) => workflow.state === "WAITING_FOR_VAULT_CONSENT",
+    ) ?? null
+  );
 }
 
 export function humanizeWorkflowKey(key: string): string {

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -60,6 +60,7 @@ import { LinkedAccounts } from "@/components/LinkedAccounts";
 import { MembershipSharingCard } from "@/components/MembershipSharingCard";
 import { ConnectedDevicesCard } from "@/components/ConnectedDevicesCard";
 import { WorkflowsCard } from "@/components/WorkflowsCard";
+import { SecureVaultCard } from "@/components/SecureVaultCard";
 import { AiAssistantCard } from "@/components/AiAssistantCard";
 import { MembershipPlanUpgradeCard } from "@/components/MembershipPlanUpgradeCard";
 import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
@@ -1136,6 +1137,12 @@ const Account = () => {
           {hasSessionToken && (
             <div className="mt-8">
               <ConnectedDevicesCard sessionToken={getSessionToken() ?? ""} />
+            </div>
+          )}
+
+          {hasSessionToken && (
+            <div id="vault" className="mt-8 scroll-mt-24">
+              <SecureVaultCard sessionToken={getSessionToken() ?? ""} />
             </div>
           )}
 


### PR DESCRIPTION
Wire the web app to backend vault APIs so users can store sensitive fields, approve per-workflow vault access, and complete applications that require vault data. Includes masked inputs, client-side validation, consent panel hardening, and cross-card refresh after consent resolves.