### PR TITLE
Use backend-driven client feature flags

### DIFF
--- a/src/components/admin/AdminSidebarLayout.tsx
+++ b/src/components/admin/AdminSidebarLayout.tsx
@@ -16,6 +16,7 @@ import {
   Megaphone,
   UserCircle,
 } from "lucide-react";
+import { useFeatureFlags } from "@/lib/feature-flags";
 
 function linkClass(isActive: boolean) {
   return [
@@ -28,6 +29,7 @@ function linkClass(isActive: boolean) {
 
 export default function AdminSidebarLayout() {
   const { admin, logout, can } = useAdminAuth();
+  const { workflowsEnabled } = useFeatureFlags();
   const navigate = useNavigate();
 
   const signOut = async () => {
@@ -103,13 +105,15 @@ export default function AdminSidebarLayout() {
               <Gift className="h-4 w-4" />
               Perks
             </NavLink>
-            <NavLink
-              to="/admin/workflows"
-              className={({ isActive }) => linkClass(isActive)}
-            >
-              <Activity className="h-4 w-4" />
-              Workflows
-            </NavLink>
+            {workflowsEnabled ? (
+              <NavLink
+                to="/admin/workflows"
+                className={({ isActive }) => linkClass(isActive)}
+              >
+                <Activity className="h-4 w-4" />
+                Workflows
+              </NavLink>
+            ) : null}
             <NavLink
               to="/admin/perk-requests"
               className={({ isActive }) => linkClass(isActive)}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { BACKEND_URL } from "@/auth/backend";
+
+export interface ClientFeatureFlags {
+  workflowsEnabled: boolean;
+  aiAssistantEnabled: boolean;
+}
+
+const DEFAULT_FLAGS: ClientFeatureFlags = {
+  workflowsEnabled: false,
+  aiAssistantEnabled: false,
+};
+
+let cachedFlags: ClientFeatureFlags | null = null;
+let inFlight: Promise<ClientFeatureFlags> | null = null;
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === true;
+}
+
+export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
+  if (cachedFlags) return cachedFlags;
+  inFlight ??= fetch(`${BACKEND_URL}/config/features`, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  })
+    .then(async (response) => {
+      if (!response.ok) return DEFAULT_FLAGS;
+      const raw: unknown = await response.json().catch(() => ({}));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return DEFAULT_FLAGS;
+      }
+      const record = raw as Record<string, unknown>;
+      return {
+        workflowsEnabled: readBoolean(record, "workflowsEnabled"),
+        aiAssistantEnabled: readBoolean(record, "aiAssistantEnabled"),
+      };
+    })
+    .catch(() => DEFAULT_FLAGS)
+    .then((flags) => {
+      cachedFlags = flags;
+      inFlight = null;
+      return flags;
+    });
+
+  return inFlight;
+}
+
+export function useFeatureFlags(): ClientFeatureFlags {
+  const [flags, setFlags] = useState<ClientFeatureFlags>(
+    cachedFlags ?? DEFAULT_FLAGS,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchClientFeatureFlags().then((nextFlags) => {
+      if (!cancelled) setFlags(nextFlags);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return flags;
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -11,24 +11,39 @@ const DEFAULT_FLAGS: ClientFeatureFlags = {
   aiAssistantEnabled: false,
 };
 
+const FLAGS_CACHE_TTL_MS = 5 * 60 * 1000;
+const FLAGS_FETCH_TIMEOUT_MS = 5000;
+
 let cachedFlags: ClientFeatureFlags | null = null;
+let cachedAt = 0;
 let inFlight: Promise<ClientFeatureFlags> | null = null;
 
 function readBoolean(record: Record<string, unknown>, key: string): boolean {
   return record[key] === true;
 }
 
+function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    FLAGS_FETCH_TIMEOUT_MS,
+  );
+
+  return fetch(url, { method: "GET", signal: controller.signal }).finally(() =>
+    window.clearTimeout(timeout),
+  );
+}
+
 export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
-  if (cachedFlags) return cachedFlags;
-  inFlight ??= fetch(`${BACKEND_URL}/config/features`, {
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-  })
+  const now = Date.now();
+  if (cachedFlags && now - cachedAt < FLAGS_CACHE_TTL_MS) return cachedFlags;
+
+  inFlight ??= fetchWithTimeout(`${BACKEND_URL}/config/features`)
     .then(async (response) => {
-      if (!response.ok) return DEFAULT_FLAGS;
+      if (!response.ok) return null;
       const raw: unknown = await response.json().catch(() => ({}));
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-        return DEFAULT_FLAGS;
+        return null;
       }
       const record = raw as Record<string, unknown>;
       return {
@@ -36,11 +51,14 @@ export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
         aiAssistantEnabled: readBoolean(record, "aiAssistantEnabled"),
       };
     })
-    .catch(() => DEFAULT_FLAGS)
+    .catch(() => null)
     .then((flags) => {
-      cachedFlags = flags;
+      if (flags) {
+        cachedFlags = flags;
+        cachedAt = Date.now();
+      }
       inFlight = null;
-      return flags;
+      return cachedFlags ?? DEFAULT_FLAGS;
     });
 
   return inFlight;

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -78,6 +78,7 @@ import {
 import { openKeenVpnAppStore } from "@/lib/keenvpn-deep-links";
 import { useSubscriptionBillingActions } from "@/hooks/use-subscription-billing-actions";
 import { useAnnualUpgrade } from "@/hooks/use-annual-upgrade";
+import { useFeatureFlags } from "@/lib/feature-flags";
 import {
   ANNUAL_UPGRADE_BANNER_DISMISS_KEY,
   AnnualUpgradeBanner,
@@ -105,6 +106,7 @@ import {
 } from "@/lib/keenvpn-deep-links";
 
 const Account = () => {
+  const { aiAssistantEnabled, workflowsEnabled } = useFeatureFlags();
   const [subscriptionLoading, setSubscriptionLoading] = useState(false);
   // true on normal /account (no session_id) — render subscription card immediately;
   // AuthContext usually has subscription already. Stripe return starts false (skeleton until sync).
@@ -1147,13 +1149,13 @@ const Account = () => {
             </div>
           )}
 
-          {hasSessionToken && (
+          {hasSessionToken && aiAssistantEnabled && (
             <div className="mt-8">
               <AiAssistantCard sessionToken={getSessionToken() ?? ""} />
             </div>
           )}
 
-          {hasSessionToken && (
+          {hasSessionToken && workflowsEnabled && (
             <div id="applications" className="mt-8 scroll-mt-24">
               <WorkflowsCard sessionToken={getSessionToken() ?? ""} />
             </div>

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -71,6 +71,7 @@ import {
 import { listWorkflows } from "@/auth/backend";
 import { trackPerksEvent } from "@/lib/product-analytics";
 import { isSafeHttpUrl } from "@/lib/safe-url";
+import { useFeatureFlags } from "@/lib/feature-flags";
 
 const CATEGORY_LABELS: Record<PerkCategory, string> = {
   privacy_security: "Privacy & Security",
@@ -206,6 +207,7 @@ function linkifyDescription(text: string): ReactNode[] {
 }
 
 const Perks = () => {
+  const { workflowsEnabled } = useFeatureFlags();
   const { user, loading: authLoading } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -366,9 +368,17 @@ const Perks = () => {
     void recordPerkEvent(session, "perk_viewed", { source: "perks_page" });
   }, [user, initialLoad, loading, refreshing, fetchError]);
 
+  const visiblePerks = useMemo(
+    () =>
+      workflowsEnabled
+        ? perks
+        : perks.filter((perk) => perk.redemptionType !== "workflow"),
+    [perks, workflowsEnabled],
+  );
+
   const featuredPerks = useMemo(
-    () => perks.filter((perk) => perk.isFeatured),
-    [perks],
+    () => visiblePerks.filter((perk) => perk.isFeatured),
+    [visiblePerks],
   );
 
   const featuredIds = useMemo(
@@ -387,16 +397,18 @@ const Perks = () => {
 
   const allSectionPerks = useMemo(
     () =>
-      showFeaturedSection ? perks.filter((p) => !featuredIds.has(p.id)) : perks,
-    [perks, showFeaturedSection, featuredIds],
+      showFeaturedSection
+        ? visiblePerks.filter((p) => !featuredIds.has(p.id))
+        : visiblePerks,
+    [visiblePerks, showFeaturedSection, featuredIds],
   );
 
   const detailsPerk = useMemo(
     () =>
       detailsPerkId
-        ? (perks.find((perk) => perk.id === detailsPerkId) ?? null)
+        ? (visiblePerks.find((perk) => perk.id === detailsPerkId) ?? null)
         : null,
-    [detailsPerkId, perks],
+    [detailsPerkId, visiblePerks],
   );
 
   useEffect(() => {

--- a/src/pages/admin/AdminPerks.tsx
+++ b/src/pages/admin/AdminPerks.tsx
@@ -371,9 +371,6 @@ export default function AdminPerks() {
   const { can } = useAdminAuth();
   const { workflowsEnabled } = useFeatureFlags();
   const canWrite = can("subscriptions.write");
-  const availableRedemptionTypes = workflowsEnabled
-    ? REDEMPTION_TYPES
-    : REDEMPTION_TYPES.filter((type) => type.value !== "workflow");
 
   const [perks, setPerks] = useState<AdminPerk[]>([]);
   const [expiredPerks, setExpiredPerks] = useState<AdminPerk[]>([]);
@@ -395,6 +392,12 @@ export default function AdminPerks() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<PerkFormState>(emptyForm());
+  const showDisabledWorkflowType =
+    !workflowsEnabled && Boolean(editingId) && form.redemptionType === "workflow";
+  const availableRedemptionTypes =
+    workflowsEnabled || showDisabledWorkflowType
+      ? REDEMPTION_TYPES
+      : REDEMPTION_TYPES.filter((type) => type.value !== "workflow");
   const [dialogError, setDialogError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -1550,8 +1553,17 @@ export default function AdminPerks() {
                   </SelectTrigger>
                   <SelectContent>
                     {availableRedemptionTypes.map((type) => (
-                      <SelectItem key={type.value} value={type.value}>
+                      <SelectItem
+                        key={type.value}
+                        value={type.value}
+                        disabled={
+                          type.value === "workflow" && !workflowsEnabled
+                        }
+                      >
                         {type.label}
+                        {type.value === "workflow" && !workflowsEnabled
+                          ? " (disabled)"
+                          : ""}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/pages/admin/AdminPerks.tsx
+++ b/src/pages/admin/AdminPerks.tsx
@@ -38,6 +38,7 @@ import {
   type PerkRedemptionType,
 } from "@/auth/backend";
 import { useAdminAuth } from "@/contexts/AdminAuthContext";
+import { useFeatureFlags } from "@/lib/feature-flags";
 import {
   AudienceTargetingPanel,
 } from "@/components/admin/AudienceTargetingPanel";
@@ -368,7 +369,11 @@ function statusLabel(status: AdminPerk["status"]) {
 
 export default function AdminPerks() {
   const { can } = useAdminAuth();
+  const { workflowsEnabled } = useFeatureFlags();
   const canWrite = can("subscriptions.write");
+  const availableRedemptionTypes = workflowsEnabled
+    ? REDEMPTION_TYPES
+    : REDEMPTION_TYPES.filter((type) => type.value !== "workflow");
 
   const [perks, setPerks] = useState<AdminPerk[]>([]);
   const [expiredPerks, setExpiredPerks] = useState<AdminPerk[]>([]);
@@ -1544,7 +1549,7 @@ export default function AdminPerks() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {REDEMPTION_TYPES.map((type) => (
+                    {availableRedemptionTypes.map((type) => (
                       <SelectItem key={type.value} value={type.value}>
                         {type.label}
                       </SelectItem>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the client to backend-driven feature flags for Workflows and AI Assistant. This lets us toggle features server‑side and hides related UI when off.

- **New Features**
  - Added `useFeatureFlags` hook that fetches from `${BACKEND_URL}/config/features` with 5‑min cache, 5‑s timeout, in‑flight request de‑duping, safe JSON parsing, and default fallbacks.
  - Account: show `AiAssistantCard` only when `aiAssistantEnabled`; show `WorkflowsCard` only when `workflowsEnabled`.
  - Admin sidebar: show the Workflows nav item only when enabled.
  - Perks: hide workflow‑type perks when disabled, including featured and details views.
  - Admin Perks: exclude the “workflow” redemption type when disabled; keep it visible (disabled, labeled) for existing items.

<sup>Written for commit 1191b990713d186d995f915254fbcbc548e6291e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Keen-VPN/website/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

