### PR TITLE
Staging

### DIFF
--- a/src/components/AccountWorkspace.tsx
+++ b/src/components/AccountWorkspace.tsx
@@ -71,17 +71,25 @@ function resolveTabFromLocation(
   search: string,
   hash: string,
 ): AccountWorkspaceTab {
-  const queryTab = new URLSearchParams(search).get("tab");
-  if (queryTab && TAB_QUERY[queryTab]) {
-    return TAB_QUERY[queryTab];
-  }
-
   const hashKey = hash.replace(/^#/, "");
   if (hashKey && TAB_HASH[hashKey]) {
     return TAB_HASH[hashKey];
   }
 
+  const queryTab = new URLSearchParams(search).get("tab");
+  if (queryTab && TAB_QUERY[queryTab]) {
+    return TAB_QUERY[queryTab];
+  }
+
   return "perks";
+}
+
+function tabFromHash(hash: string): AccountWorkspaceTab | null {
+  const hashKey = hash.replace(/^#/, "");
+  if (hashKey && TAB_HASH[hashKey]) {
+    return TAB_HASH[hashKey];
+  }
+  return null;
 }
 
 function hashForTab(tab: AccountWorkspaceTab): string | null {
@@ -130,7 +138,36 @@ export function AccountWorkspace({
   useEffect(() => {
     const nextTab = resolveTabFromLocation(location.search, location.hash);
     setActiveTab((current) => (current === nextTab ? current : nextTab));
-  }, [location.search, location.hash]);
+
+    const hashTab = tabFromHash(location.hash);
+    if (!hashTab) return;
+
+    const params = new URLSearchParams(location.search);
+    const queryTab = params.get("tab");
+    if (queryTab === hashTab) return;
+
+    params.set("tab", hashTab);
+    const nextHash = hashForTab(hashTab);
+    navigate(
+      `${location.pathname}?${params.toString()}${
+        nextHash ? `#${nextHash}` : ""
+      }`,
+      { replace: true },
+    );
+  }, [location.search, location.hash, location.pathname, navigate]);
+
+  useEffect(() => {
+    const hashKey = location.hash.replace(/^#/, "");
+    if (!hashKey || !TAB_HASH[hashKey]) return;
+
+    const anchor = document.getElementById(hashKey);
+    if (!anchor) return;
+
+    const frame = window.requestAnimationFrame(() => {
+      anchor.scrollIntoView({ block: "start" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [location.hash, activeTab]);
 
   useEffect(() => {
     const activePanel = bodyScrollRef.current?.querySelector<HTMLElement>(
@@ -150,6 +187,7 @@ export function AccountWorkspace({
   const tabPanelClassName = cn(
     "absolute inset-0 mt-0 overflow-y-auto overscroll-contain p-4 sm:p-5",
     "focus-visible:outline-none",
+    "data-[state=inactive]:hidden",
   );
 
   return (
@@ -201,23 +239,28 @@ export function AccountWorkspace({
             <div ref={bodyScrollRef} className="relative min-h-0 flex-1">
               <TabsContent
                 value="perks"
-                id="applications"
-                className={cn(tabPanelClassName, "scroll-mt-24 space-y-4")}
+                forceMount
+                className={cn(tabPanelClassName, "space-y-4")}
               >
-                <WorkflowsCard sessionToken={sessionToken} />
-                <AiAssistantCard sessionToken={sessionToken} />
+                <div id="applications" className="scroll-mt-24 space-y-4">
+                  <WorkflowsCard sessionToken={sessionToken} />
+                  <AiAssistantCard sessionToken={sessionToken} />
+                </div>
               </TabsContent>
 
               <TabsContent
                 value="vault"
-                id="vault"
-                className={cn(tabPanelClassName, "scroll-mt-24")}
+                forceMount
+                className={tabPanelClassName}
               >
-                <SecureVaultCard sessionToken={sessionToken} />
+                <div id="vault" className="scroll-mt-24">
+                  <SecureVaultCard sessionToken={sessionToken} />
+                </div>
               </TabsContent>
 
               <TabsContent
                 value="profile"
+                forceMount
                 className={cn(tabPanelClassName, "space-y-4")}
               >
                 <div className="grid gap-4 xl:grid-cols-2">
@@ -228,6 +271,7 @@ export function AccountWorkspace({
 
               <TabsContent
                 value="connections"
+                forceMount
                 className={cn(tabPanelClassName, "space-y-4")}
               >
                 <div className="grid gap-4 xl:grid-cols-2">

--- a/src/components/AccountWorkspace.tsx
+++ b/src/components/AccountWorkspace.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Gift, Link2, Lock, UserRound, Users } from "lucide-react";
+import { LinkedAccounts } from "@/components/LinkedAccounts";
+import { MembershipSharingCard } from "@/components/MembershipSharingCard";
+import { ConnectedDevicesCard } from "@/components/ConnectedDevicesCard";
+import { WorkflowsCard } from "@/components/WorkflowsCard";
+import { SecureVaultCard } from "@/components/SecureVaultCard";
+import { AiAssistantCard } from "@/components/AiAssistantCard";
+import { UserInformationCard } from "@/components/UserInformationCard";
+import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
+import { cn } from "@/lib/utils";
+
+export type AccountWorkspaceTab =
+  | "perks"
+  | "vault"
+  | "profile"
+  | "connections";
+
+const TAB_HASH: Record<string, AccountWorkspaceTab> = {
+  vault: "vault",
+  applications: "perks",
+};
+
+const TAB_QUERY: Record<string, AccountWorkspaceTab> = {
+  perks: "perks",
+  applications: "perks",
+  vault: "vault",
+  profile: "profile",
+  connections: "connections",
+};
+
+const TAB_META: Record<
+  AccountWorkspaceTab,
+  { label: string; description: string; icon: typeof Gift }
+> = {
+  perks: {
+    label: "Perks",
+    description: "Applications and your AI assistant",
+    icon: Gift,
+  },
+  vault: {
+    label: "Vault",
+    description: "Encrypted personal details for perks",
+    icon: Lock,
+  },
+  profile: {
+    label: "Profile",
+    description: "Your information and email preferences",
+    icon: UserRound,
+  },
+  connections: {
+    label: "Connections",
+    description: "Linked accounts, devices, and sharing",
+    icon: Link2,
+  },
+};
+
+const WORKSPACE_BODY_HEIGHT =
+  "h-[min(28rem,calc(100dvh-20rem))] sm:h-[min(32rem,calc(100dvh-18rem))]";
+
+function resolveTabFromLocation(
+  search: string,
+  hash: string,
+): AccountWorkspaceTab {
+  const queryTab = new URLSearchParams(search).get("tab");
+  if (queryTab && TAB_QUERY[queryTab]) {
+    return TAB_QUERY[queryTab];
+  }
+
+  const hashKey = hash.replace(/^#/, "");
+  if (hashKey && TAB_HASH[hashKey]) {
+    return TAB_HASH[hashKey];
+  }
+
+  return "perks";
+}
+
+function hashForTab(tab: AccountWorkspaceTab): string | null {
+  if (tab === "vault") return "vault";
+  if (tab === "perks") return "applications";
+  return null;
+}
+
+interface AccountWorkspaceProps {
+  sessionToken: string;
+  authProvider?: string;
+  linkedProviders: {
+    google: { linked: boolean; email?: string };
+    apple: { linked: boolean; email?: string };
+  } | null;
+  onLinkedAccountsUpdate: () => void;
+}
+
+export function AccountWorkspace({
+  sessionToken,
+  authProvider,
+  linkedProviders,
+  onLinkedAccountsUpdate,
+}: AccountWorkspaceProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const bodyScrollRef = useRef<HTMLDivElement>(null);
+  const [activeTab, setActiveTab] = useState<AccountWorkspaceTab>(() =>
+    resolveTabFromLocation(location.search, location.hash),
+  );
+
+  const syncLocationToTab = useCallback(
+    (tab: AccountWorkspaceTab) => {
+      const params = new URLSearchParams(location.search);
+      params.set("tab", tab);
+      const nextHash = hashForTab(tab);
+      const nextSearch = params.toString();
+      const nextUrl = `${location.pathname}?${nextSearch}${
+        nextHash ? `#${nextHash}` : ""
+      }`;
+      navigate(nextUrl, { replace: true });
+    },
+    [location.pathname, location.search, navigate],
+  );
+
+  useEffect(() => {
+    const nextTab = resolveTabFromLocation(location.search, location.hash);
+    setActiveTab((current) => (current === nextTab ? current : nextTab));
+  }, [location.search, location.hash]);
+
+  useEffect(() => {
+    const activePanel = bodyScrollRef.current?.querySelector<HTMLElement>(
+      '[role="tabpanel"][data-state="active"]',
+    );
+    activePanel?.scrollTo({ top: 0 });
+  }, [activeTab]);
+
+  const handleTabChange = (value: string) => {
+    const tab = value as AccountWorkspaceTab;
+    setActiveTab(tab);
+    syncLocationToTab(tab);
+  };
+
+  const activeMeta = TAB_META[activeTab];
+
+  const tabPanelClassName = cn(
+    "absolute inset-0 mt-0 overflow-y-auto overscroll-contain p-4 sm:p-5",
+    "focus-visible:outline-none",
+  );
+
+  return (
+    <Card className="mt-10 overflow-hidden border-accent/40 bg-gradient-card shadow-card">
+      <CardHeader className="border-b border-border/60 pb-4">
+        <CardTitle className="text-2xl">Workspace</CardTitle>
+        <CardDescription>
+          Manage perks, your secure vault, profile, and connected accounts.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="p-4 sm:p-6">
+        <Tabs value={activeTab} onValueChange={handleTabChange}>
+          <TabsList className="grid h-10 w-full grid-cols-4 gap-1 rounded-lg bg-muted/50 p-1">
+            {(Object.keys(TAB_META) as AccountWorkspaceTab[]).map((tab) => {
+              const meta = TAB_META[tab];
+              const Icon = meta.icon;
+              return (
+                <TabsTrigger
+                  key={tab}
+                  value={tab}
+                  className={cn(
+                    "flex h-8 items-center justify-center gap-1.5 rounded-md px-1.5 text-xs font-medium sm:px-2 sm:text-sm",
+                    "text-muted-foreground",
+                    "data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+                  )}
+                >
+                  <Icon className="hidden h-3.5 w-3.5 shrink-0 sm:block" />
+                  <span className="truncate">{meta.label}</span>
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+
+          <div
+            className={cn(
+              "mt-4 flex flex-col overflow-hidden rounded-xl border border-border/70 bg-muted/15",
+              WORKSPACE_BODY_HEIGHT,
+            )}
+          >
+            <div className="shrink-0 border-b border-border/50 px-4 py-2.5 sm:px-5">
+              <h3 className="text-sm font-semibold text-foreground sm:text-base">
+                {activeMeta.label}
+              </h3>
+              <p className="text-xs text-muted-foreground sm:text-sm">
+                {activeMeta.description}
+              </p>
+            </div>
+
+            <div ref={bodyScrollRef} className="relative min-h-0 flex-1">
+              <TabsContent
+                value="perks"
+                id="applications"
+                className={cn(tabPanelClassName, "scroll-mt-24 space-y-4")}
+              >
+                <WorkflowsCard sessionToken={sessionToken} />
+                <AiAssistantCard sessionToken={sessionToken} />
+              </TabsContent>
+
+              <TabsContent
+                value="vault"
+                id="vault"
+                className={cn(tabPanelClassName, "scroll-mt-24")}
+              >
+                <SecureVaultCard sessionToken={sessionToken} />
+              </TabsContent>
+
+              <TabsContent
+                value="profile"
+                className={cn(tabPanelClassName, "space-y-4")}
+              >
+                <div className="grid gap-4 xl:grid-cols-2">
+                  <UserInformationCard sessionToken={sessionToken} />
+                  <EmailPreferencesCard sessionToken={sessionToken} />
+                </div>
+              </TabsContent>
+
+              <TabsContent
+                value="connections"
+                className={cn(tabPanelClassName, "space-y-4")}
+              >
+                <div className="grid gap-4 xl:grid-cols-2">
+                  <LinkedAccounts
+                    sessionToken={sessionToken}
+                    currentProvider={authProvider}
+                    providers={linkedProviders}
+                    onUpdate={onLinkedAccountsUpdate}
+                  />
+                  <ConnectedDevicesCard sessionToken={sessionToken} />
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2 px-1 text-xs text-muted-foreground sm:text-sm">
+                    <Users className="h-3.5 w-3.5 text-primary" />
+                    <span>Membership sharing for business plans</span>
+                  </div>
+                  <MembershipSharingCard sessionToken={sessionToken} />
+                </div>
+              </TabsContent>
+            </div>
+          </div>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/AiAssistantCard.tsx
+++ b/src/components/AiAssistantCard.tsx
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel";
+import { workspaceAlertBanner } from "@/components/workspace/workspace-ui";
 import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -231,18 +226,12 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
 
   if (loading) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5" />
-            AI Assistant
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex items-center gap-2 text-muted-foreground">
+      <WorkspacePanel title="AI Assistant" icon={Sparkles}>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading…
-        </CardContent>
-      </Card>
+        </div>
+      </WorkspacePanel>
     );
   }
 
@@ -254,38 +243,30 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
   const hasDraft = Boolean(draft.trim());
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-start justify-between gap-3">
-          <CardTitle className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5" />
-            AI Assistant
-          </CardTitle>
-          {(visibleMessages.length > 0 || hasDraft) && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-8 gap-1.5 px-2 text-xs"
-              onClick={() => void handleNewChat()}
-              disabled={sending}
-            >
-              <RotateCcw className="h-3.5 w-3.5" aria-hidden />
-              New chat
-            </Button>
-          )}
-        </div>
-        <CardDescription>
-          Tell KeenVPN what you&apos;d like help with. We&apos;ll find the right
-          application and guide you through it. Nothing is ever submitted
-          without your explicit approval.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
+    <WorkspacePanel
+      title="AI Assistant"
+      icon={Sparkles}
+      description="Tell KeenVPN what you'd like help with. We'll find the right application and guide you through it. Nothing is ever submitted without your explicit approval."
+      headerAction={
+        (visibleMessages.length > 0 || hasDraft) ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5 px-2 text-xs"
+            onClick={() => void handleNewChat()}
+            disabled={sending}
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden />
+            New chat
+          </Button>
+        ) : undefined
+      }
+    >
         {error && <p className="text-sm text-destructive">{error}</p>}
 
         {pendingVaultConsentWorkflowId && (
-          <div className="flex items-start gap-2 rounded-md bg-muted/40 p-3 text-sm">
+          <div className={workspaceAlertBanner}>
             <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden />
             <p>
               An application needs your permission to access information in your{" "}
@@ -302,7 +283,7 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
         )}
 
         {pendingApproval && (
-          <div className="flex items-start gap-2 rounded-md bg-muted/40 p-3 text-sm">
+          <div className={workspaceAlertBanner}>
             <AlertCircle
               className="mt-0.5 h-4 w-4 shrink-0 text-primary"
               aria-hidden
@@ -319,7 +300,7 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
           </div>
         )}
 
-        <ScrollArea className="h-80 rounded-md border">
+        <ScrollArea className="h-80 rounded-lg border border-border/80 bg-background/70 shadow-sm">
           <div className="space-y-3 p-4">
             {visibleMessages.length === 0 ? (
               <div className="space-y-4">
@@ -406,7 +387,6 @@ export function AiAssistantCard({ sessionToken }: AiAssistantCardProps) {
             )}
           </Button>
         </div>
-      </CardContent>
-    </Card>
+    </WorkspacePanel>
   );
 }

--- a/src/components/ConnectedDevicesCard.tsx
+++ b/src/components/ConnectedDevicesCard.tsx
@@ -1,18 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel";
+import {
+  workspaceListRow,
+  workspaceListSurface,
+} from "@/components/workspace/workspace-ui";
 import { Loader2, MonitorSmartphone } from "lucide-react";
 import {
   fetchDeviceConnectionsStatus,
   restoreDeviceConnection,
   revokeDeviceConnection,
 } from "@/auth/backend";
+import { cn } from "@/lib/utils";
 
 interface ConnectedDevicesCardProps {
   sessionToken: string;
@@ -143,18 +142,12 @@ export function ConnectedDevicesCard({
 
   if (loading) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <MonitorSmartphone className="h-5 w-5" />
-            Connected devices
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex items-center gap-2 text-muted-foreground">
+      <WorkspacePanel title="Connected devices" icon={MonitorSmartphone}>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading devices…
-        </CardContent>
-      </Card>
+        </div>
+      </WorkspacePanel>
     );
   }
 
@@ -164,17 +157,9 @@ export function ConnectedDevicesCard({
 
   if (error && !status) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <MonitorSmartphone className="h-5 w-5" />
-            Connected devices
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-destructive">{error}</p>
-        </CardContent>
-      </Card>
+      <WorkspacePanel title="Connected devices" icon={MonitorSmartphone}>
+        <p className="text-sm text-destructive">{error}</p>
+      </WorkspacePanel>
     );
   }
 
@@ -183,18 +168,11 @@ export function ConnectedDevicesCard({
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <MonitorSmartphone className="h-5 w-5" />
-          Connected devices
-        </CardTitle>
-        <CardDescription>
-          {status.activeCount} of {status.limit} devices connected ·{" "}
-          {status.available} available
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
+    <WorkspacePanel
+      title="Connected devices"
+      icon={MonitorSmartphone}
+      description={`${status.activeCount} of ${status.limit} devices connected · ${status.available} available`}
+    >
         {error && <p className="text-sm text-destructive">{error}</p>}
         {status.devices.length === 0 ? (
           <p className="text-sm text-muted-foreground">
@@ -202,11 +180,14 @@ export function ConnectedDevicesCard({
             from the KeenVPN app.
           </p>
         ) : (
-          <ul className="divide-y rounded-md border">
+          <ul className={workspaceListSurface}>
             {status.devices.map((device) => (
               <li
                 key={device.id}
-                className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+                className={cn(
+                  workspaceListRow,
+                  "flex flex-wrap items-center justify-between gap-3",
+                )}
               >
                 <div>
                   <p className="font-medium">{deviceLabel(device)}</p>
@@ -239,11 +220,14 @@ export function ConnectedDevicesCard({
         {(status.revokedDevices?.length ?? 0) > 0 ? (
           <div className="space-y-2">
             <p className="text-sm font-medium">Removed devices</p>
-            <ul className="divide-y rounded-md border">
+            <ul className={workspaceListSurface}>
               {status.revokedDevices?.map((device) => (
                 <li
                   key={device.id}
-                  className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+                  className={cn(
+                    workspaceListRow,
+                    "flex flex-wrap items-center justify-between gap-3",
+                  )}
                 >
                   <div>
                     <p className="font-medium">{deviceLabel(device)}</p>
@@ -273,7 +257,6 @@ export function ConnectedDevicesCard({
             </ul>
           </div>
         ) : null}
-      </CardContent>
-    </Card>
+    </WorkspacePanel>
   );
 }

--- a/src/components/EmailPreferencesCard.tsx
+++ b/src/components/EmailPreferencesCard.tsx
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel";
+import { workspaceSectionSurface } from "@/components/workspace/workspace-ui";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
@@ -74,15 +69,12 @@ export function EmailPreferencesCard({ sessionToken }: EmailPreferencesCardProps
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Email preferences</CardTitle>
-        <CardDescription>
-          Control optional personalized emails from KeenVPN
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="flex items-start justify-between gap-4">
+    <WorkspacePanel
+      title="Email preferences"
+      description="Control optional personalized emails from KeenVPN"
+    >
+        <div className={workspaceSectionSurface}>
+          <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
             <Label htmlFor="contextual-email-opt-in" className="text-base">
               Domain Insights for Perks
@@ -115,8 +107,8 @@ export function EmailPreferencesCard({ sessionToken }: EmailPreferencesCardProps
               onCheckedChange={(checked) => void handleToggle(checked)}
             />
           )}
+          </div>
         </div>
-      </CardContent>
-    </Card>
+    </WorkspacePanel>
   );
 }

--- a/src/components/LinkedAccounts.tsx
+++ b/src/components/LinkedAccounts.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { WorkspacePanel } from '@/components/workspace/WorkspacePanel';
+import {
+  workspaceListRow,
+  workspaceListSurface,
+} from '@/components/workspace/workspace-ui';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -16,6 +20,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useToast } from '@/hooks/use-toast';
 import { linkProvider, unlinkProvider } from '@/auth/backend';
+import { cn } from '@/lib/utils';
 import { getFirebaseAuth, getFirebaseApp } from '@/auth/firebase';
 import {
   linkWithPopup,
@@ -149,11 +154,8 @@ export function LinkedAccounts({ sessionToken, currentProvider, providers, onUpd
 
   if (!providers) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle>Linked Accounts</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
+      <WorkspacePanel title="Linked Accounts">
+        <div className="space-y-3">
           <div className="flex items-center justify-between">
             <Skeleton className="h-5 w-24" />
             <Skeleton className="h-6 w-16 rounded-full" />
@@ -162,8 +164,8 @@ export function LinkedAccounts({ sessionToken, currentProvider, providers, onUpd
             <Skeleton className="h-5 w-20" />
             <Skeleton className="h-9 w-32 rounded-md" />
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </WorkspacePanel>
     );
   }
 
@@ -176,19 +178,15 @@ export function LinkedAccounts({ sessionToken, currentProvider, providers, onUpd
   if (!showGoogle && !showApple) return null;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Linked Accounts</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Primary provider indicator */}
-        <div className="flex items-center justify-between">
+    <WorkspacePanel title="Linked Accounts">
+      <ul className={workspaceListSurface}>
+        <li className={cn(workspaceListRow, "flex items-center justify-between")}>
           <span className="font-medium">{isGoogle ? 'Google' : 'Apple'}</span>
           <Badge variant="outline">Primary</Badge>
-        </div>
+        </li>
 
         {showGoogle && (
-          <div className="flex items-center justify-between">
+          <li className={cn(workspaceListRow, "flex items-center justify-between")}>
             <span className="font-medium">Google</span>
             {providers.google.linked ? (
               <AlertDialog>
@@ -227,10 +225,10 @@ export function LinkedAccounts({ sessionToken, currentProvider, providers, onUpd
                 {linking === 'google' ? 'Linking...' : 'Link Google Account'}
               </Button>
             )}
-          </div>
+          </li>
         )}
         {showApple && (
-          <div className="flex items-center justify-between">
+          <li className={cn(workspaceListRow, "flex items-center justify-between")}>
             <span className="font-medium">Apple</span>
             {providers.apple.linked ? (
               <AlertDialog>
@@ -269,9 +267,9 @@ export function LinkedAccounts({ sessionToken, currentProvider, providers, onUpd
                 {linking === 'apple' ? 'Linking...' : 'Link Apple Account'}
               </Button>
             )}
-          </div>
+          </li>
         )}
-      </CardContent>
-    </Card>
+      </ul>
+    </WorkspacePanel>
   );
 }

--- a/src/components/MembershipSharingCard.tsx
+++ b/src/components/MembershipSharingCard.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel";
+import {
+  workspaceEmptyState,
+  workspaceListRow,
+  workspaceSectionSurface,
+} from "@/components/workspace/workspace-ui";
 import { Input } from "@/components/ui/input";
 import { Loader2, Users } from "lucide-react";
 import {
@@ -19,6 +18,7 @@ import {
 } from "@/auth/backend";
 import { MIN_BUSINESS_SEATS, MAX_BUSINESS_SEATS } from "@/constants/pricing";
 import { Link } from "react-router-dom";
+import { cn } from "@/lib/utils";
 
 interface MembershipSharingCardProps {
   sessionToken: string;
@@ -202,75 +202,53 @@ export function MembershipSharingCard({
 
   if (loading) {
     return (
-      <Card>
-        <CardContent className="flex items-center gap-2 py-8 text-muted-foreground">
+      <WorkspacePanel title="Membership sharing" icon={Users}>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading membership sharing…
-        </CardContent>
-      </Card>
+        </div>
+      </WorkspacePanel>
     );
   }
 
   if (!dashboard) {
     if (!error) return null;
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Users className="h-5 w-5" />
-            Membership sharing
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-destructive">{error}</p>
-        </CardContent>
-      </Card>
+      <WorkspacePanel title="Membership sharing" icon={Users}>
+        <p className="text-sm text-destructive">{error}</p>
+      </WorkspacePanel>
     );
   }
 
   if (dashboard.role === "member" && dashboard.membership) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Users className="h-5 w-5" />
-            Shared membership
-          </CardTitle>
-          <CardDescription>
-            Premium access through {dashboard.membership.ownerEmail}
-            {dashboard.membership.planName
-              ? ` (${dashboard.membership.planName})`
-              : ""}
-            .
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <WorkspacePanel
+        title="Shared membership"
+        icon={Users}
+        description={`Premium access through ${dashboard.membership.ownerEmail}${
+          dashboard.membership.planName
+            ? ` (${dashboard.membership.planName})`
+            : ""
+        }.`}
+      />
     );
   }
 
   if (!dashboard.eligible) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Users className="h-5 w-5" />
-            Membership sharing
-          </CardTitle>
-          <CardDescription>
-            Invite team members to share your KeenVPN Business subscription.
-            Available on the Business plan.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
-            Upgrade to a Business plan to invite members with their own login
-            credentials.
-          </p>
-          <Button asChild className="mt-4" variant="outline">
-            <Link to="/pricing">View Business plan</Link>
-          </Button>
-        </CardContent>
-      </Card>
+      <WorkspacePanel
+        title="Membership sharing"
+        icon={Users}
+        description="Invite team members to share your KeenVPN Business subscription. Available on the Business plan."
+      >
+        <p className={cn(workspaceEmptyState, "text-sm text-muted-foreground")}>
+          Upgrade to a Business plan to invite members with their own login
+          credentials.
+        </p>
+        <Button asChild className="mt-4" variant="outline">
+          <Link to="/pricing">View Business plan</Link>
+        </Button>
+      </WorkspacePanel>
     );
   }
 
@@ -290,23 +268,19 @@ export function MembershipSharingCard({
   const seatsChanged = effectiveDraftSeats !== currentSeatLimit;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Users className="h-5 w-5" />
-          Membership sharing
-        </CardTitle>
-        <CardDescription>
-          {seats
-            ? `${seats.activeSeats} of ${seats.seatLimit} seats used · ${seats.availableSeats} available`
-            : "Invite others to share your subscription."}
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
+    <WorkspacePanel
+      title="Membership sharing"
+      icon={Users}
+      description={
+        seats
+          ? `${seats.activeSeats} of ${seats.seatLimit} seats used · ${seats.availableSeats} available`
+          : "Invite others to share your subscription."
+      }
+    >
         {error ? <p className="text-sm text-destructive">{error}</p> : null}
 
         {dashboard.canManageSeats && seats ? (
-          <div className="space-y-2 rounded-md border bg-muted/30 p-4">
+          <div className={workspaceSectionSurface}>
             <h3 className="text-sm font-medium">Manage seats</h3>
             <p className="text-xs text-muted-foreground">
               Add or remove seats on your Business subscription. Stripe prorates
@@ -387,7 +361,7 @@ export function MembershipSharingCard({
             </div>
           </div>
         ) : (
-          <p className="rounded-md border bg-muted/40 p-3 text-sm text-muted-foreground">
+          <p className={cn(workspaceEmptyState, "text-sm text-muted-foreground")}>
             {currentSeatLimit <= 1
               ? "Membership sharing is not enabled on this subscription. Upgrade to Business to invite team members."
               : "All seats are currently used. Remove a member, cancel a pending invite, or add more seats."}
@@ -401,7 +375,10 @@ export function MembershipSharingCard({
               {dashboard.members.map((member) => (
                 <li
                   key={member.userId}
-                  className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                  className={cn(
+                    workspaceListRow,
+                    "flex flex-col gap-2 rounded-lg border border-border/80 sm:flex-row sm:items-center sm:justify-between",
+                  )}
                 >
                   <div>
                     <p className="font-medium">{member.email}</p>
@@ -430,7 +407,10 @@ export function MembershipSharingCard({
               {dashboard.pendingInvites.map((invite) => (
                 <li
                   key={invite.id}
-                  className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between"
+                  className={cn(
+                    workspaceListRow,
+                    "flex flex-col gap-2 rounded-lg border border-border/80 sm:flex-row sm:items-center sm:justify-between",
+                  )}
                 >
                   <div>
                     <p className="font-medium">{invite.email}</p>
@@ -482,7 +462,6 @@ export function MembershipSharingCard({
             </ul>
           </div>
         ) : null}
-      </CardContent>
-    </Card>
+    </WorkspacePanel>
   );
 }

--- a/src/components/SecureVaultCard.tsx
+++ b/src/components/SecureVaultCard.tsx
@@ -1,11 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -19,7 +12,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Loader2, Lock, Shield } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { ChevronRight, Loader2, Lock, Shield } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import {
   deleteVaultField,
@@ -34,6 +35,7 @@ import {
   getVaultFieldValidationError,
   isSensitiveVaultField,
 } from "@/lib/vault-fields";
+import { cn } from "@/lib/utils";
 
 const CATEGORY_LABELS: Record<string, string> = {
   IDENTITY: "Identity",
@@ -51,8 +53,11 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
   const [loading, setLoading] = useState(true);
   const [featureDisabled, setFeatureDisabled] = useState(false);
   const [sections, setSections] = useState<VaultOverviewSection[]>([]);
-  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [activeField, setActiveField] = useState<VaultFieldMetadata | null>(
+    null,
+  );
   const [editValue, setEditValue] = useState("");
+  const [loadingFieldValue, setLoadingFieldValue] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldToDelete, setFieldToDelete] = useState<VaultFieldMetadata | null>(
@@ -91,29 +96,37 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
     };
   }, [load]);
 
-  async function startEdit(field: VaultFieldMetadata) {
-    const requestedFieldKey = field.fieldKey;
-    editRequestKeyRef.current = requestedFieldKey;
-    setEditingKey(field.fieldKey);
+  function closeFieldModal() {
+    if (saving || loadingFieldValue) return;
+    editRequestKeyRef.current = null;
+    setActiveField(null);
     setEditValue("");
     setError(null);
-    if (field.isStored) {
-      const res = await getVaultFieldValue(sessionToken, field.fieldKey);
-      if (editRequestKeyRef.current !== requestedFieldKey) {
-        return;
-      }
-      if (res.ok && res.data?.field) {
-        setEditValue(res.data.field.value);
-      } else {
-        setError(res.error ?? `Failed to load ${field.label}`);
-      }
-    }
   }
 
-  function cancelEdit() {
-    editRequestKeyRef.current = null;
-    setEditingKey(null);
+  async function openField(field: VaultFieldMetadata) {
+    const requestedFieldKey = field.fieldKey;
+    editRequestKeyRef.current = requestedFieldKey;
+    setActiveField(field);
     setEditValue("");
+    setError(null);
+    setLoadingFieldValue(field.isStored);
+
+    if (!field.isStored) {
+      setLoadingFieldValue(false);
+      return;
+    }
+
+    const res = await getVaultFieldValue(sessionToken, field.fieldKey);
+    if (editRequestKeyRef.current !== requestedFieldKey) {
+      return;
+    }
+    if (res.ok && res.data?.field) {
+      setEditValue(res.data.field.value);
+    } else {
+      setError(res.error ?? `Failed to load ${field.label}`);
+    }
+    setLoadingFieldValue(false);
   }
 
   async function handleSave(field: VaultFieldMetadata) {
@@ -134,7 +147,7 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
       }
       toast({ title: `${field.label} saved securely` });
       editRequestKeyRef.current = null;
-      setEditingKey(null);
+      setActiveField(null);
       setEditValue("");
       await load();
     } finally {
@@ -152,7 +165,9 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
         return;
       }
       toast({ title: `${field.label} removed from vault` });
-      if (editingKey === field.fieldKey) cancelEdit();
+      editRequestKeyRef.current = null;
+      setActiveField(null);
+      setEditValue("");
       setFieldToDelete(null);
       await load();
     } finally {
@@ -162,18 +177,10 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
 
   if (loading) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Shield className="h-5 w-5" />
-            Secure Vault
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex items-center gap-2 text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading…
-        </CardContent>
-      </Card>
+      <div className="flex items-center gap-2 rounded-xl border border-border/70 bg-card/90 px-4 py-6 text-muted-foreground shadow-sm">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading secure vault…
+      </div>
     );
   }
 
@@ -182,109 +189,203 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Shield className="h-5 w-5" />
-          Secure Vault
-        </CardTitle>
-        <CardDescription>
-          Store sensitive details encrypted. Partner applications only access
-          vault fields after you explicitly approve each request.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
-        {error && <p className="text-sm text-destructive">{error}</p>}
+    <>
+      <div className="space-y-5">
+        <div className="rounded-xl border border-primary/20 bg-gradient-to-br from-primary/10 via-card to-card px-4 py-4 shadow-sm sm:px-5">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-primary/25 bg-primary/15 text-primary">
+              <Shield className="h-5 w-5" aria-hidden />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <h3 className="text-base font-semibold text-foreground">
+                Secure Vault
+              </h3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Store sensitive details encrypted. Partner applications only
+                access vault fields after you explicitly approve each request.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {error && !activeField ? (
+          <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
 
         {sections.map((section) => (
-          <div key={section.category} className="space-y-3">
-            <h3 className="text-sm font-medium">
+          <section
+            key={section.category}
+            className="rounded-xl border border-border/80 bg-muted/25 p-3 shadow-sm sm:p-4"
+          >
+            <h3 className="mb-3 border-b border-border/70 pb-2 text-xs font-semibold uppercase tracking-[0.14em] text-foreground/80">
               {CATEGORY_LABELS[section.category] ?? section.category}
             </h3>
-            <ul className="space-y-3">
-              {section.fields.map((field) => {
-                const isEditing = editingKey === field.fieldKey;
-                return (
-                  <li
-                    key={field.fieldKey}
-                    className="rounded-md border p-3 space-y-2"
+            <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {section.fields.map((field) => (
+                <li key={field.fieldKey}>
+                  <button
+                    type="button"
+                    onClick={() => void openField(field)}
+                    disabled={saving}
+                    className={cn(
+                      "group flex h-full w-full flex-col rounded-lg border p-3.5 text-left transition-all",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                      field.isStored
+                        ? "border-primary/30 bg-card shadow-sm hover:border-primary/50 hover:bg-card/95"
+                        : "border-dashed border-muted-foreground/35 bg-background/70 hover:border-primary/40 hover:bg-muted/40",
+                    )}
                   >
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <div className="flex items-center gap-2">
-                        <Lock className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
-                        <span className="font-medium text-sm">{field.label}</span>
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <span
+                          className={cn(
+                            "flex h-7 w-7 shrink-0 items-center justify-center rounded-md border",
+                            field.isStored
+                              ? "border-primary/25 bg-primary/10 text-primary"
+                              : "border-border/80 bg-muted/60 text-muted-foreground",
+                          )}
+                        >
+                          <Lock className="h-3.5 w-3.5" aria-hidden />
+                        </span>
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {field.label}
+                        </span>
                       </div>
+                      <ChevronRight
+                        className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
+                        aria-hidden
+                      />
+                    </div>
+
+                    <div className="mt-3 flex items-center justify-between gap-2 border-t border-border/50 pt-2.5">
                       {field.isStored ? (
-                        <Badge variant="secondary" className="text-[10px]">
+                        <Badge
+                          variant="secondary"
+                          className="border border-primary/20 bg-primary/10 text-[10px] text-primary"
+                        >
                           {field.maskedPreview ?? "On file"}
                         </Badge>
                       ) : (
-                        <Badge variant="outline" className="text-[10px]">
+                        <Badge
+                          variant="outline"
+                          className="border-muted-foreground/40 bg-background/80 text-[10px] text-muted-foreground"
+                        >
                           Not stored
                         </Badge>
                       )}
-                    </div>
-
-                    {isEditing ? (
-                      <div className="space-y-2">
-                        <Label htmlFor={`vault-${field.fieldKey}`}>{field.label}</Label>
-                        <VaultFieldInput
-                          id={`vault-${field.fieldKey}`}
-                          inputType={field.inputType}
-                          value={editValue}
-                          onChange={setEditValue}
-                          disabled={saving}
-                          sensitive={isSensitiveVaultField(field.fieldKey)}
-                        />
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            size="sm"
-                            onClick={() => void handleSave(field)}
-                            disabled={saving}
-                          >
-                            {saving ? (
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-                            ) : null}
-                            Save
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={cancelEdit}
-                            disabled={saving}
-                          >
-                            Cancel
-                          </Button>
-                          {field.isStored ? (
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="text-destructive"
-                              onClick={() => setFieldToDelete(field)}
-                              disabled={saving}
-                            >
-                              Remove
-                            </Button>
-                          ) : null}
-                        </div>
-                      </div>
-                    ) : (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => void startEdit(field)}
-                        disabled={saving}
+                      <span
+                        className={cn(
+                          "text-xs font-medium",
+                          field.isStored
+                            ? "text-muted-foreground"
+                            : "text-primary",
+                        )}
                       >
                         {field.isStored ? "Update" : "Add"}
-                      </Button>
-                    )}
-                  </li>
-                );
-              })}
+                      </span>
+                    </div>
+                  </button>
+                </li>
+              ))}
             </ul>
-          </div>
+          </section>
         ))}
-      </CardContent>
+      </div>
+
+      <Dialog
+        open={activeField !== null}
+        onOpenChange={(open) => {
+          if (!open) closeFieldModal();
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          {activeField ? (
+            <>
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Lock className="h-4 w-4 text-muted-foreground" />
+                  {activeField.label}
+                </DialogTitle>
+                <DialogDescription>
+                  {activeField.isStored
+                    ? "Update this encrypted field in your vault."
+                    : "Add this field to your secure vault."}
+                </DialogDescription>
+              </DialogHeader>
+
+              <div className="space-y-3 py-1">
+                {error ? (
+                  <p className="text-sm text-destructive">{error}</p>
+                ) : null}
+
+                {loadingFieldValue ? (
+                  <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading secure value…
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <Label htmlFor={`vault-${activeField.fieldKey}`}>
+                      {activeField.label}
+                    </Label>
+                    <VaultFieldInput
+                      id={`vault-${activeField.fieldKey}`}
+                      inputType={activeField.inputType}
+                      value={editValue}
+                      onChange={setEditValue}
+                      disabled={saving}
+                      sensitive={isSensitiveVaultField(activeField.fieldKey)}
+                    />
+                  </div>
+                )}
+              </div>
+
+              <DialogFooter
+                className={cn(
+                  "gap-2",
+                  activeField.isStored
+                    ? "flex-col sm:flex-row sm:justify-between"
+                    : "sm:justify-end",
+                )}
+              >
+                {activeField.isStored ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="text-destructive hover:text-destructive sm:mr-auto"
+                    onClick={() => setFieldToDelete(activeField)}
+                    disabled={saving || loadingFieldValue}
+                  >
+                    Remove
+                  </Button>
+                ) : null}
+                <div className="flex w-full gap-2 sm:w-auto">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={closeFieldModal}
+                    disabled={saving || loadingFieldValue}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={() => void handleSave(activeField)}
+                    disabled={saving || loadingFieldValue}
+                  >
+                    {saving ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+                    ) : null}
+                    Save
+                  </Button>
+                </div>
+              </DialogFooter>
+            </>
+          ) : null}
+        </DialogContent>
+      </Dialog>
 
       <AlertDialog
         open={fieldToDelete !== null}
@@ -316,6 +417,6 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Card>
+    </>
   );
 }

--- a/src/components/UserInformationCard.tsx
+++ b/src/components/UserInformationCard.tsx
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel";
+import { workspaceSectionSurface } from "@/components/workspace/workspace-ui";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Loader2 } from "lucide-react";
@@ -129,15 +124,10 @@ export function UserInformationCard({
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>User information</CardTitle>
-        <CardDescription>
-          Optional details to personalize perks, offers, and recommendations.
-          You can skip any question and update your answers later.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-6">
+    <WorkspacePanel
+      title="User information"
+      description="Optional details to personalize perks, offers, and recommendations. You can skip any question and update your answers later."
+    >
         {loading ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -165,7 +155,11 @@ export function UserInformationCard({
             ) : null}
 
             {visibleProfileQuestions(questions, answers).map((question) => (
-              <div key={question.key} className="space-y-3">
+              <div
+                key={question.key}
+                className={workspaceSectionSurface}
+              >
+                <div className="space-y-3">
                 <div className="flex items-start justify-between gap-4">
                   <Label className="text-base leading-snug">
                     {question.label}
@@ -197,11 +191,11 @@ export function UserInformationCard({
                     </div>
                   ))}
                 </RadioGroup>
+                </div>
               </div>
             ))}
           </>
         )}
-      </CardContent>
-    </Card>
+    </WorkspacePanel>
   );
 }

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { WorkspacePanel } from "@/components/workspace/WorkspacePanel";
 import {
-  workspaceAlertBanner,
   workspaceEmptyState,
   workspaceListRow,
   workspaceListSurface,

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { WorkspacePanel } from "@/components/workspace/WorkspacePanel";
+import {
+  workspaceAlertBanner,
+  workspaceEmptyState,
+  workspaceListRow,
+  workspaceListSurface,
+  workspaceSectionSurface,
+} from "@/components/workspace/workspace-ui";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import {
@@ -39,6 +40,7 @@ import {
   selectPrimaryActiveWorkflow,
   workflowStateBadge,
 } from "@/lib/workflow-ui";
+import { cn } from "@/lib/utils";
 
 interface WorkflowsCardProps {
   sessionToken: string;
@@ -304,18 +306,12 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
 
   if (loading) {
     return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5" />
-            Applications
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex items-center gap-2 text-muted-foreground">
+      <WorkspacePanel title="Applications" icon={Sparkles}>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading…
-        </CardContent>
-      </Card>
+        </div>
+      </WorkspacePanel>
     );
   }
 
@@ -326,23 +322,15 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
   const badge = active ? workflowStateBadge(active.workflow.state) : null;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Sparkles className="h-5 w-5" />
-          Applications
-        </CardTitle>
-        <CardDescription>
-          Let KeenVPN guide you through partner applications, step by step.
-          We&apos;ll only submit anything on your behalf after you explicitly
-          approve it.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
+    <WorkspacePanel
+      title="Applications"
+      icon={Sparkles}
+      description="Let KeenVPN guide you through partner applications, step by step. We'll only submit anything on your behalf after you explicitly approve it."
+    >
         {error && <p className="text-sm text-destructive">{error}</p>}
 
         {!active ? (
-          <div className="rounded-md border border-dashed p-4 text-center space-y-3">
+          <div className={cn(workspaceEmptyState, "space-y-3")}>
             <p className="text-sm text-muted-foreground">
               No application in progress. Explore Perks to let KeenVPN
               auto-apply to partner offers on your behalf.
@@ -355,7 +343,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
             </Button>
           </div>
         ) : (
-          <div className="space-y-4 rounded-md border p-4">
+          <div className={cn(workspaceSectionSurface, "space-y-4")}>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
                 <p className="font-medium">
@@ -417,7 +405,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
             )}
 
             {active.workflow.state === "WAITING_FOR_INPUT" && (
-              <div className="space-y-4 rounded-md bg-muted/40 p-3">
+              <div className={cn(workspaceSectionSurface, "space-y-4 bg-card/80")}>
                 <p className="text-sm font-medium">
                   We need a bit more information to continue.
                 </p>
@@ -453,7 +441,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
             )}
 
             {active.workflow.state === "WAITING_FOR_APPROVAL" && (
-              <div className="space-y-3 rounded-md bg-muted/40 p-3">
+              <div className={cn(workspaceSectionSurface, "space-y-3 bg-card/80")}>
                 <p className="text-sm font-medium">
                   Your approval is needed for &quot;
                   {humanize(active.workflow.currentStepKey ?? "")}&quot; before
@@ -495,7 +483,7 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
             )}
 
             {active.workflow.state === "WAITING_FOR_PARTNER_ACTION" && (
-              <div className="rounded-lg border bg-muted/40 p-3 text-sm text-muted-foreground">
+              <div className={cn(workspaceSectionSurface, "text-sm text-muted-foreground")}>
                 {active.workflow.partnerName ?? "The partner"} is waiting for
                 browser review or partner action. We will update this
                 application after that step is completed.
@@ -564,13 +552,16 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
               )}
             </Button>
             {showHistory && (
-              <ul className="mt-2 divide-y rounded-md border">
+              <ul className={cn(workspaceListSurface, "mt-2")}>
                 {history.map((workflow) => {
                   const historyBadge = workflowStateBadge(workflow.state);
                   return (
                     <li
                       key={workflow.id}
-                      className="flex flex-wrap items-center justify-between gap-2 px-4 py-3"
+                      className={cn(
+                        workspaceListRow,
+                        "flex flex-wrap items-center justify-between gap-2",
+                      )}
                     >
                       <div>
                         <p className="font-medium">
@@ -593,7 +584,6 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
             )}
           </div>
         )}
-      </CardContent>
-    </Card>
+    </WorkspacePanel>
   );
 }

--- a/src/components/admin/AdminSidebarLayout.tsx
+++ b/src/components/admin/AdminSidebarLayout.tsx
@@ -16,6 +16,7 @@ import {
   Megaphone,
   UserCircle,
 } from "lucide-react";
+import { useFeatureFlags } from "@/lib/feature-flags";
 
 function linkClass(isActive: boolean) {
   return [
@@ -28,6 +29,7 @@ function linkClass(isActive: boolean) {
 
 export default function AdminSidebarLayout() {
   const { admin, logout, can } = useAdminAuth();
+  const { workflowsEnabled } = useFeatureFlags();
   const navigate = useNavigate();
 
   const signOut = async () => {
@@ -103,13 +105,15 @@ export default function AdminSidebarLayout() {
               <Gift className="h-4 w-4" />
               Perks
             </NavLink>
-            <NavLink
-              to="/admin/workflows"
-              className={({ isActive }) => linkClass(isActive)}
-            >
-              <Activity className="h-4 w-4" />
-              Workflows
-            </NavLink>
+            {workflowsEnabled ? (
+              <NavLink
+                to="/admin/workflows"
+                className={({ isActive }) => linkClass(isActive)}
+              >
+                <Activity className="h-4 w-4" />
+                Workflows
+              </NavLink>
+            ) : null}
             <NavLink
               to="/admin/perk-requests"
               className={({ isActive }) => linkClass(isActive)}

--- a/src/components/workspace/WorkspacePanel.tsx
+++ b/src/components/workspace/WorkspacePanel.tsx
@@ -1,0 +1,60 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import {
+  workspacePanelBody,
+  workspacePanelHeader,
+  workspacePanelSurface,
+} from "@/components/workspace/workspace-ui";
+
+interface WorkspacePanelProps {
+  title: ReactNode;
+  description?: ReactNode;
+  icon?: LucideIcon;
+  headerAction?: ReactNode;
+  children?: ReactNode;
+  className?: string;
+  bodyClassName?: string;
+}
+
+export function WorkspacePanel({
+  title,
+  description,
+  icon: Icon,
+  headerAction,
+  children,
+  className,
+  bodyClassName,
+}: WorkspacePanelProps) {
+  return (
+    <section className={cn(workspacePanelSurface, className)}>
+      <div className={workspacePanelHeader}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 items-start gap-3">
+            {Icon ? (
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-primary/20 bg-primary/10 text-primary">
+                <Icon className="h-4 w-4" aria-hidden />
+              </div>
+            ) : null}
+            <div className="min-w-0 space-y-1">
+              <h3 className="text-base font-semibold leading-tight text-foreground">
+                {title}
+              </h3>
+              {description ? (
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {description}
+                </p>
+              ) : null}
+            </div>
+          </div>
+          {headerAction ? (
+            <div className="shrink-0">{headerAction}</div>
+          ) : null}
+        </div>
+      </div>
+      {children ? (
+        <div className={cn(workspacePanelBody, bodyClassName)}>{children}</div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/workspace/workspace-ui.ts
+++ b/src/components/workspace/workspace-ui.ts
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+
+/** Elevated surface for panels nested inside AccountWorkspace tab content. */
+export const workspacePanelSurface =
+  "rounded-xl border border-border/80 bg-card shadow-sm";
+
+export const workspacePanelHeader =
+  "border-b border-border/60 px-4 py-3.5 sm:px-5";
+
+export const workspacePanelBody = "space-y-4 px-4 py-4 sm:px-5";
+
+/** Grouped content blocks inside a workspace panel. */
+export const workspaceSectionSurface = cn(
+  "rounded-lg border border-border/80 bg-muted/25 p-3 shadow-sm sm:p-4",
+);
+
+/** List containers (devices, history, members, etc.). */
+export const workspaceListSurface = cn(
+  "overflow-hidden rounded-lg border border-border/80 bg-background/70 shadow-sm divide-y divide-border/60",
+);
+
+export const workspaceListRow = "bg-card px-4 py-3";
+
+/** Empty / placeholder states. */
+export const workspaceEmptyState = cn(
+  "rounded-lg border border-dashed border-muted-foreground/35 bg-background/70 p-4 text-center",
+);
+
+/** Info / alert callouts inside workspace panels. */
+export const workspaceAlertBanner = cn(
+  "flex items-start gap-2 rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm",
+);

--- a/src/hooks/use-friends-badge.ts
+++ b/src/hooks/use-friends-badge.ts
@@ -18,7 +18,7 @@ const POLL_INTERVAL_MS = 60_000;
 
 export function useFriendsBadge(options?: { poll?: boolean }): FriendsBadgeState {
   const poll = options?.poll ?? true;
-  const { user, getSessionToken: authGetSessionToken } = useAuth();
+  const { user, hasSessionToken } = useAuth();
   const [state, setState] = useState<FriendsBadgeState>({
     pendingReceived: 0,
     unreadNotifications: 0,
@@ -29,7 +29,7 @@ export function useFriendsBadge(options?: { poll?: boolean }): FriendsBadgeState
   const requestRef = useRef(0);
 
   const refresh = useCallback(async () => {
-    const sessionToken = authGetSessionToken() ?? getSessionToken();
+    const sessionToken = hasSessionToken ? getSessionToken() : null;
     if (!user || !sessionToken) {
       setState({
         pendingReceived: 0,
@@ -80,7 +80,7 @@ export function useFriendsBadge(options?: { poll?: boolean }): FriendsBadgeState
       loading: false,
       enabled: true,
     });
-  }, [authGetSessionToken, user]);
+  }, [hasSessionToken, user]);
 
   useEffect(() => {
     if (!poll) return;

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchClientFeatureFlags,
+  resetFeatureFlags,
+} from "./feature-flags";
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    json: async () => body,
+  } as Response;
+}
+
+describe("fetchClientFeatureFlags reset races", () => {
+  beforeEach(() => {
+    resetFeatureFlags();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    resetFeatureFlags();
+    vi.unstubAllGlobals();
+  });
+
+  it("ignores stale in-flight responses after reset", async () => {
+    let resolveFetch!: (value: Response) => void;
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+
+    vi.mocked(fetch).mockReturnValue(fetchPromise as Promise<Response>);
+
+    const first = fetchClientFeatureFlags();
+    resetFeatureFlags();
+
+    resolveFetch(
+      jsonResponse({
+        workflowsEnabled: true,
+        aiAssistantEnabled: true,
+      }),
+    );
+
+    await expect(first).resolves.toEqual({
+      workflowsEnabled: false,
+      aiAssistantEnabled: false,
+    });
+
+    vi.mocked(fetch).mockResolvedValue(
+      jsonResponse({
+        workflowsEnabled: false,
+        aiAssistantEnabled: true,
+      }),
+    );
+
+    await expect(fetchClientFeatureFlags()).resolves.toEqual({
+      workflowsEnabled: false,
+      aiAssistantEnabled: true,
+    });
+  });
+
+  it("does not let a stale response overwrite a newer cache", async () => {
+    let resolveFirst!: (value: Response) => void;
+    const firstFetch = new Promise<Response>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    vi.mocked(fetch).mockReturnValueOnce(firstFetch as Promise<Response>);
+
+    const staleRequest = fetchClientFeatureFlags();
+    resetFeatureFlags();
+
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        workflowsEnabled: false,
+        aiAssistantEnabled: true,
+      }),
+    );
+
+    const freshRequest = fetchClientFeatureFlags();
+    await expect(freshRequest).resolves.toEqual({
+      workflowsEnabled: false,
+      aiAssistantEnabled: true,
+    });
+
+    resolveFirst(
+      jsonResponse({
+        workflowsEnabled: true,
+        aiAssistantEnabled: true,
+      }),
+    );
+
+    await expect(staleRequest).resolves.toEqual({
+      workflowsEnabled: false,
+      aiAssistantEnabled: true,
+    });
+    await expect(fetchClientFeatureFlags()).resolves.toEqual({
+      workflowsEnabled: false,
+      aiAssistantEnabled: true,
+    });
+  });
+
+  it("aborts the outstanding request on reset", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.mocked(fetch).mockImplementation((_url, init) => {
+      capturedSignal = init?.signal ?? undefined;
+      return new Promise<Response>(() => {});
+    });
+
+    void fetchClientFeatureFlags();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    resetFeatureFlags();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+});

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -18,8 +18,14 @@ let cachedFlags: ClientFeatureFlags | null = null;
 let cachedAt = 0;
 let inFlight: Promise<ClientFeatureFlags> | null = null;
 
-function readBoolean(record: Record<string, unknown>, key: string): boolean {
+function isExplicitlyTrue(record: Record<string, unknown>, key: string): boolean {
   return record[key] === true;
+}
+
+export function resetFeatureFlags(): void {
+  cachedFlags = null;
+  cachedAt = 0;
+  inFlight = null;
 }
 
 function fetchWithTimeout(url: string): Promise<Response> {
@@ -47,8 +53,8 @@ export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
       }
       const record = raw as Record<string, unknown>;
       return {
-        workflowsEnabled: readBoolean(record, "workflowsEnabled"),
-        aiAssistantEnabled: readBoolean(record, "aiAssistantEnabled"),
+        workflowsEnabled: isExplicitlyTrue(record, "workflowsEnabled"),
+        aiAssistantEnabled: isExplicitlyTrue(record, "aiAssistantEnabled"),
       };
     })
     .catch(() => null)

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { BACKEND_URL } from "@/auth/backend";
+
+export interface ClientFeatureFlags {
+  workflowsEnabled: boolean;
+  aiAssistantEnabled: boolean;
+}
+
+const DEFAULT_FLAGS: ClientFeatureFlags = {
+  workflowsEnabled: false,
+  aiAssistantEnabled: false,
+};
+
+let cachedFlags: ClientFeatureFlags | null = null;
+let inFlight: Promise<ClientFeatureFlags> | null = null;
+
+function readBoolean(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === true;
+}
+
+export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
+  if (cachedFlags) return cachedFlags;
+  inFlight ??= fetch(`${BACKEND_URL}/config/features`, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  })
+    .then(async (response) => {
+      if (!response.ok) return DEFAULT_FLAGS;
+      const raw: unknown = await response.json().catch(() => ({}));
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+        return DEFAULT_FLAGS;
+      }
+      const record = raw as Record<string, unknown>;
+      return {
+        workflowsEnabled: readBoolean(record, "workflowsEnabled"),
+        aiAssistantEnabled: readBoolean(record, "aiAssistantEnabled"),
+      };
+    })
+    .catch(() => DEFAULT_FLAGS)
+    .then((flags) => {
+      cachedFlags = flags;
+      inFlight = null;
+      return flags;
+    });
+
+  return inFlight;
+}
+
+export function useFeatureFlags(): ClientFeatureFlags {
+  const [flags, setFlags] = useState<ClientFeatureFlags>(
+    cachedFlags ?? DEFAULT_FLAGS,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchClientFeatureFlags().then((nextFlags) => {
+      if (!cancelled) setFlags(nextFlags);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return flags;
+}

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -16,8 +16,10 @@ const FLAGS_FETCH_TIMEOUT_MS = 5000;
 
 let cachedFlags: ClientFeatureFlags | null = null;
 let cachedAt = 0;
-let inFlight: Promise<ClientFeatureFlags> | null = null;
 let cacheGeneration = 0;
+let inFlight: Promise<ClientFeatureFlags> | null = null;
+let inFlightGeneration = -1;
+let inFlightAbort: AbortController | null = null;
 
 function isExplicitlyTrue(record: Record<string, unknown>, key: string): boolean {
   return record[key] === true;
@@ -27,18 +29,33 @@ export function resetFeatureFlags(): void {
   cacheGeneration += 1;
   cachedFlags = null;
   cachedAt = 0;
+  inFlightAbort?.abort();
+  inFlightAbort = null;
   inFlight = null;
+  inFlightGeneration = -1;
 }
 
-function fetchWithTimeout(url: string): Promise<Response> {
+function fetchWithTimeout(
+  url: string,
+  externalSignal?: AbortSignal,
+): Promise<Response> {
   const controller = new AbortController();
   const timeout = window.setTimeout(
     () => controller.abort(),
     FLAGS_FETCH_TIMEOUT_MS,
   );
 
-  return fetch(url, { method: "GET", signal: controller.signal }).finally(() =>
-    window.clearTimeout(timeout),
+  const abortFromExternal = () => controller.abort();
+  externalSignal?.addEventListener("abort", abortFromExternal, { once: true });
+  if (externalSignal?.aborted) {
+    controller.abort();
+  }
+
+  return fetch(url, { method: "GET", signal: controller.signal }).finally(
+    () => {
+      window.clearTimeout(timeout);
+      externalSignal?.removeEventListener("abort", abortFromExternal);
+    },
   );
 }
 
@@ -47,8 +64,20 @@ export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
   if (cachedFlags && now - cachedAt < FLAGS_CACHE_TTL_MS) return cachedFlags;
 
   const requestGeneration = cacheGeneration;
-  inFlight ??= fetchWithTimeout(`${BACKEND_URL}/config/features`)
+  if (inFlight && inFlightGeneration === requestGeneration) {
+    return inFlight;
+  }
+
+  const abortController = new AbortController();
+  inFlightAbort = abortController;
+  inFlightGeneration = requestGeneration;
+
+  const request = fetchWithTimeout(
+    `${BACKEND_URL}/config/features`,
+    abortController.signal,
+  )
     .then(async (response) => {
+      if (requestGeneration !== cacheGeneration) return null;
       if (!response.ok) return null;
       const raw: unknown = await response.json().catch(() => ({}));
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
@@ -69,11 +98,16 @@ export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
         cachedFlags = flags;
         cachedAt = Date.now();
       }
-      inFlight = null;
+      if (inFlightGeneration === requestGeneration) {
+        inFlight = null;
+        inFlightAbort = null;
+        inFlightGeneration = -1;
+      }
       return cachedFlags ?? DEFAULT_FLAGS;
     });
 
-  return inFlight;
+  inFlight = request;
+  return request;
 }
 
 export function useFeatureFlags(): ClientFeatureFlags {

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -17,12 +17,14 @@ const FLAGS_FETCH_TIMEOUT_MS = 5000;
 let cachedFlags: ClientFeatureFlags | null = null;
 let cachedAt = 0;
 let inFlight: Promise<ClientFeatureFlags> | null = null;
+let cacheGeneration = 0;
 
 function isExplicitlyTrue(record: Record<string, unknown>, key: string): boolean {
   return record[key] === true;
 }
 
 export function resetFeatureFlags(): void {
+  cacheGeneration += 1;
   cachedFlags = null;
   cachedAt = 0;
   inFlight = null;
@@ -44,6 +46,7 @@ export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
   const now = Date.now();
   if (cachedFlags && now - cachedAt < FLAGS_CACHE_TTL_MS) return cachedFlags;
 
+  const requestGeneration = cacheGeneration;
   inFlight ??= fetchWithTimeout(`${BACKEND_URL}/config/features`)
     .then(async (response) => {
       if (!response.ok) return null;
@@ -59,6 +62,9 @@ export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
     })
     .catch(() => null)
     .then((flags) => {
+      if (requestGeneration !== cacheGeneration) {
+        return cachedFlags ?? DEFAULT_FLAGS;
+      }
       if (flags) {
         cachedFlags = flags;
         cachedAt = Date.now();

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -11,24 +11,39 @@ const DEFAULT_FLAGS: ClientFeatureFlags = {
   aiAssistantEnabled: false,
 };
 
+const FLAGS_CACHE_TTL_MS = 5 * 60 * 1000;
+const FLAGS_FETCH_TIMEOUT_MS = 5000;
+
 let cachedFlags: ClientFeatureFlags | null = null;
+let cachedAt = 0;
 let inFlight: Promise<ClientFeatureFlags> | null = null;
 
 function readBoolean(record: Record<string, unknown>, key: string): boolean {
   return record[key] === true;
 }
 
+function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    FLAGS_FETCH_TIMEOUT_MS,
+  );
+
+  return fetch(url, { method: "GET", signal: controller.signal }).finally(() =>
+    window.clearTimeout(timeout),
+  );
+}
+
 export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
-  if (cachedFlags) return cachedFlags;
-  inFlight ??= fetch(`${BACKEND_URL}/config/features`, {
-    method: "GET",
-    headers: { "Content-Type": "application/json" },
-  })
+  const now = Date.now();
+  if (cachedFlags && now - cachedAt < FLAGS_CACHE_TTL_MS) return cachedFlags;
+
+  inFlight ??= fetchWithTimeout(`${BACKEND_URL}/config/features`)
     .then(async (response) => {
-      if (!response.ok) return DEFAULT_FLAGS;
+      if (!response.ok) return null;
       const raw: unknown = await response.json().catch(() => ({}));
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-        return DEFAULT_FLAGS;
+        return null;
       }
       const record = raw as Record<string, unknown>;
       return {
@@ -36,11 +51,14 @@ export async function fetchClientFeatureFlags(): Promise<ClientFeatureFlags> {
         aiAssistantEnabled: readBoolean(record, "aiAssistantEnabled"),
       };
     })
-    .catch(() => DEFAULT_FLAGS)
+    .catch(() => null)
     .then((flags) => {
-      cachedFlags = flags;
+      if (flags) {
+        cachedFlags = flags;
+        cachedAt = Date.now();
+      }
       inFlight = null;
-      return flags;
+      return cachedFlags ?? DEFAULT_FLAGS;
     });
 
   return inFlight;

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -56,15 +56,8 @@ import {
 } from "@/auth";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-import { LinkedAccounts } from "@/components/LinkedAccounts";
-import { MembershipSharingCard } from "@/components/MembershipSharingCard";
-import { ConnectedDevicesCard } from "@/components/ConnectedDevicesCard";
-import { WorkflowsCard } from "@/components/WorkflowsCard";
-import { SecureVaultCard } from "@/components/SecureVaultCard";
-import { AiAssistantCard } from "@/components/AiAssistantCard";
+import { AccountWorkspace } from "@/components/AccountWorkspace";
 import { MembershipPlanUpgradeCard } from "@/components/MembershipPlanUpgradeCard";
-import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
-import { UserInformationCard } from "@/components/UserInformationCard";
 import { SubscriptionCancellationControls } from "@/components/SubscriptionCancellationControls";
 import {
   isAppDeepLinkSupported,
@@ -629,24 +622,21 @@ const Account = () => {
               </Card>
             </div>
 
-            {/* Linked Accounts Skeleton */}
-            <div className="mt-8">
-              <Card>
-                <CardHeader>
-                  <CardTitle>Linked Accounts</CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <Skeleton className="h-5 w-24" />
-                    <Skeleton className="h-6 w-16 rounded-full" />
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <Skeleton className="h-5 w-20" />
-                    <Skeleton className="h-9 w-32 rounded-md" />
-                  </div>
-                </CardContent>
-              </Card>
-            </div>
+            <Card className="mt-10 border-accent/40 shadow-card">
+              <CardHeader>
+                <Skeleton className="h-7 w-36" />
+                <Skeleton className="mt-2 h-4 w-full max-w-md" />
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                  <Skeleton className="h-20 rounded-lg" />
+                  <Skeleton className="h-20 rounded-lg" />
+                  <Skeleton className="h-20 rounded-lg" />
+                  <Skeleton className="h-20 rounded-lg" />
+                </div>
+                <Skeleton className="h-64 w-full rounded-xl" />
+              </CardContent>
+            </Card>
           </div>
         </main>
         <Footer />
@@ -727,8 +717,8 @@ const Account = () => {
             <h1 className="text-4xl font-bold text-foreground mb-4">
               My <span className="text-primary">Account</span>
             </h1>
-            <p className="text-xl text-muted-foreground">
-              Manage your KeenVPN subscription and account settings
+            <p className="text-lg text-muted-foreground">
+              Subscription, perks, and account settings — organized in one place.
             </p>
           </div>
 
@@ -1128,162 +1118,118 @@ const Account = () => {
             </Card>
           </div>
 
-          {/* Linked Accounts */}
           {hasSessionToken && (
-            <div className="mt-8">
-              <MembershipSharingCard sessionToken={getSessionToken() ?? ""} />
-            </div>
+            <AccountWorkspace
+              sessionToken={getSessionToken() ?? ""}
+              authProvider={authProvider ?? undefined}
+              linkedProviders={linkedProviders}
+              onLinkedAccountsUpdate={() => {
+                refreshLinkedProviders();
+                refreshSubscription();
+              }}
+            />
           )}
 
-          {hasSessionToken && (
-            <div className="mt-8">
-              <ConnectedDevicesCard sessionToken={getSessionToken() ?? ""} />
-            </div>
-          )}
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            <Card className="border-accent/40 shadow-card">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-lg">Need help?</CardTitle>
+                <CardDescription>
+                  Our support team can help with billing, perks, and account
+                  issues.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <a
+                  href="mailto:support@vpnkeen.com?subject=Support Request&body=Hello KeenVPN Support Team,%0D%0A%0D%0AI need assistance with:%0D%0A%0D%0A[Please describe your issue here]%0D%0A%0D%0AThank you!"
+                  className="inline-flex h-10 w-full items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  Contact Support
+                </a>
+              </CardContent>
+            </Card>
 
-          {hasSessionToken && (
-            <div id="vault" className="mt-8 scroll-mt-24">
-              <SecureVaultCard sessionToken={getSessionToken() ?? ""} />
-            </div>
-          )}
-
-          {hasSessionToken && (
-            <div className="mt-8">
-              <AiAssistantCard sessionToken={getSessionToken() ?? ""} />
-            </div>
-          )}
-
-          {hasSessionToken && (
-            <div id="applications" className="mt-8 scroll-mt-24">
-              <WorkflowsCard sessionToken={getSessionToken() ?? ""} />
-            </div>
-          )}
-
-          {hasSessionToken && (
-            <div className="mt-8">
-              <LinkedAccounts
-                sessionToken={getSessionToken() ?? ""}
-                currentProvider={authProvider ?? undefined}
-                providers={linkedProviders}
-                onUpdate={() => {
-                  refreshLinkedProviders();
-                  refreshSubscription();
-                }}
-              />
-            </div>
-          )}
-
-          {hasSessionToken && (
-            <div className="mt-8">
-              <UserInformationCard sessionToken={getSessionToken() ?? ""} />
-            </div>
-          )}
-
-          {hasSessionToken && (
-            <div className="mt-8">
-              <EmailPreferencesCard sessionToken={getSessionToken() ?? ""} />
-            </div>
-          )}
-
-          {/* Support Section */}
-          <Card className="mt-8 border-accent/50 shadow-glow">
-            <CardHeader>
-              <CardTitle>Need Help?</CardTitle>
-              <CardDescription>
-                Contact our support team for assistance with your account
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <a
-                href="mailto:support@vpnkeen.com?subject=Support Request&body=Hello KeenVPN Support Team,%0D%0A%0D%0AI need assistance with:%0D%0A%0D%0A[Please describe your issue here]%0D%0A%0D%0AThank you!"
-                className="w-full inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2"
-              >
-                Contact Support
-              </a>
-            </CardContent>
-          </Card>
-
-          {/* Danger Zone */}
-          <Card className="mt-8 border-destructive/50">
-            <CardHeader>
-              <CardTitle className="text-destructive flex items-center">
-                <AlertTriangle className="h-5 w-5 mr-2" />
-                Danger Zone
-              </CardTitle>
-              <CardDescription>
-                Irreversible and destructive actions
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    variant="destructive"
-                    className="w-full"
-                    disabled={deleting}
-                  >
-                    {deleting ? (
-                      <>
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                        Deleting Account...
-                      </>
-                    ) : (
-                      <>
-                        <Trash2 className="h-4 w-4 mr-2" />
-                        Delete Account
-                      </>
-                    )}
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle className="flex items-center text-destructive">
-                      <AlertTriangle className="h-5 w-5 mr-2" />
-                      Are you absolutely sure?
-                    </AlertDialogTitle>
-                    <AlertDialogDescription className="space-y-3">
-                      <p>
-                        This action <strong>cannot be undone</strong>. Your
-                        account and all associated usage data will be
-                        permanently deleted from our servers. Please note that
-                        no refunds will be issued.
-                      </p>
-                      <div className="bg-destructive/10 p-3 rounded-lg border border-destructive/20">
-                        <p className="text-sm font-medium text-destructive">
-                          This will delete:
-                        </p>
-                        <ul className="text-sm text-muted-foreground mt-2 space-y-1 list-disc list-inside">
-                          <li>Your account and profile information</li>
-                          <li>All subscription data</li>
-                          <li>All associated preferences and settings</li>
-                        </ul>
-                      </div>
-                      {subscription && subscription.status === "active" && (
-                        <div className="bg-yellow-50 p-3 rounded-lg border border-yellow-200">
-                          <p className="text-sm font-medium text-yellow-800">
-                            ⚠️ You have an active subscription
-                          </p>
-                          <p className="text-xs text-yellow-700 mt-1">
-                            Please cancel your subscription before deleting your
-                            account to avoid future charges.
-                          </p>
-                        </div>
-                      )}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>Cancel</AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={handleDeleteAccount}
-                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            <Card className="border-destructive/40 shadow-card">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center text-lg text-destructive">
+                  <AlertTriangle className="mr-2 h-5 w-5" />
+                  Danger zone
+                </CardTitle>
+                <CardDescription>
+                  Permanently delete your account and associated data.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="destructive"
+                      className="w-full"
+                      disabled={deleting}
                     >
-                      Delete Account Permanently
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </CardContent>
-          </Card>
+                      {deleting ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Deleting Account...
+                        </>
+                      ) : (
+                        <>
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          Delete Account
+                        </>
+                      )}
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle className="flex items-center text-destructive">
+                        <AlertTriangle className="mr-2 h-5 w-5" />
+                        Are you absolutely sure?
+                      </AlertDialogTitle>
+                      <AlertDialogDescription className="space-y-3">
+                        <p>
+                          This action <strong>cannot be undone</strong>. Your
+                          account and all associated usage data will be
+                          permanently deleted from our servers. Please note that
+                          no refunds will be issued.
+                        </p>
+                        <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-3">
+                          <p className="text-sm font-medium text-destructive">
+                            This will delete:
+                          </p>
+                          <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-muted-foreground">
+                            <li>Your account and profile information</li>
+                            <li>All subscription data</li>
+                            <li>All associated preferences and settings</li>
+                          </ul>
+                        </div>
+                        {subscription && subscription.status === "active" && (
+                          <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-3">
+                            <p className="text-sm font-medium text-yellow-800">
+                              You have an active subscription
+                            </p>
+                            <p className="mt-1 text-xs text-yellow-700">
+                              Please cancel your subscription before deleting your
+                              account to avoid future charges.
+                            </p>
+                          </div>
+                        )}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={handleDeleteAccount}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      >
+                        Delete Account Permanently
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </CardContent>
+            </Card>
+          </div>
         </div>
       </main>
       <Footer />

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -78,6 +78,7 @@ import {
 import { openKeenVpnAppStore } from "@/lib/keenvpn-deep-links";
 import { useSubscriptionBillingActions } from "@/hooks/use-subscription-billing-actions";
 import { useAnnualUpgrade } from "@/hooks/use-annual-upgrade";
+import { useFeatureFlags } from "@/lib/feature-flags";
 import {
   ANNUAL_UPGRADE_BANNER_DISMISS_KEY,
   AnnualUpgradeBanner,
@@ -105,6 +106,7 @@ import {
 } from "@/lib/keenvpn-deep-links";
 
 const Account = () => {
+  const { aiAssistantEnabled, workflowsEnabled } = useFeatureFlags();
   const [subscriptionLoading, setSubscriptionLoading] = useState(false);
   // true on normal /account (no session_id) — render subscription card immediately;
   // AuthContext usually has subscription already. Stripe return starts false (skeleton until sync).
@@ -1147,13 +1149,13 @@ const Account = () => {
             </div>
           )}
 
-          {hasSessionToken && (
+          {hasSessionToken && aiAssistantEnabled && (
             <div className="mt-8">
               <AiAssistantCard sessionToken={getSessionToken() ?? ""} />
             </div>
           )}
 
-          {hasSessionToken && (
+          {hasSessionToken && workflowsEnabled && (
             <div id="applications" className="mt-8 scroll-mt-24">
               <WorkflowsCard sessionToken={getSessionToken() ?? ""} />
             </div>

--- a/src/pages/Friends.tsx
+++ b/src/pages/Friends.tsx
@@ -130,7 +130,7 @@ function displayLabel(row: {
 }
 
 export default function Friends() {
-  const { getSessionToken: authGetSessionToken } = useAuth();
+  const { hasSessionToken } = useAuth();
   const { toast } = useToast();
   const [dashboard, setDashboard] = useState<DashboardData | null>(null);
   const [notifications, setNotifications] = useState<FriendNotification[]>([]);
@@ -145,7 +145,7 @@ export default function Friends() {
   const loadRequestRef = useRef(0);
 
   const load = useCallback(async () => {
-    const sessionToken = authGetSessionToken() ?? getSessionToken();
+    const sessionToken = hasSessionToken ? getSessionToken() : null;
     if (!sessionToken) {
       setError("Please sign in to view your friends network.");
       setLoading(false);
@@ -189,7 +189,7 @@ export default function Friends() {
     } finally {
       if (isCurrent()) setLoading(false);
     }
-  }, [authGetSessionToken]);
+  }, [hasSessionToken]);
 
   useEffect(() => {
     void load();
@@ -199,7 +199,7 @@ export default function Friends() {
     action: (token: string) => Promise<{ ok: boolean; error?: string }>,
     successMessage: string,
   ): Promise<boolean> {
-    const sessionToken = authGetSessionToken() ?? getSessionToken();
+    const sessionToken = hasSessionToken ? getSessionToken() : null;
     if (!sessionToken) return false;
     setSubmitting(true);
     try {

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -376,6 +376,25 @@ const Perks = () => {
     [perks, workflowsEnabled],
   );
 
+  const visibleCategories = useMemo(() => {
+    if (workflowsEnabled) return categories;
+    const nonWorkflowCategories = new Set(
+      perks
+        .filter((perk) => perk.redemptionType !== "workflow")
+        .map((perk) => perk.category),
+    );
+    return categories.filter((category) => nonWorkflowCategories.has(category));
+  }, [categories, perks, workflowsEnabled]);
+
+  useEffect(() => {
+    if (
+      selectedCategory !== "all" &&
+      !visibleCategories.includes(selectedCategory)
+    ) {
+      setSelectedCategory("all");
+    }
+  }, [selectedCategory, visibleCategories]);
+
   const featuredPerks = useMemo(
     () => visiblePerks.filter((perk) => perk.isFeatured),
     [visiblePerks],
@@ -817,7 +836,7 @@ const Perks = () => {
                   >
                     All
                   </Button>
-                  {categories.map((cat) => (
+                  {visibleCategories.map((cat) => (
                     <Button
                       key={cat}
                       size="sm"

--- a/src/pages/Perks.tsx
+++ b/src/pages/Perks.tsx
@@ -71,6 +71,7 @@ import {
 import { listWorkflows } from "@/auth/backend";
 import { trackPerksEvent } from "@/lib/product-analytics";
 import { isSafeHttpUrl } from "@/lib/safe-url";
+import { useFeatureFlags } from "@/lib/feature-flags";
 
 const CATEGORY_LABELS: Record<PerkCategory, string> = {
   privacy_security: "Privacy & Security",
@@ -206,6 +207,7 @@ function linkifyDescription(text: string): ReactNode[] {
 }
 
 const Perks = () => {
+  const { workflowsEnabled } = useFeatureFlags();
   const { user, loading: authLoading } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
@@ -366,9 +368,17 @@ const Perks = () => {
     void recordPerkEvent(session, "perk_viewed", { source: "perks_page" });
   }, [user, initialLoad, loading, refreshing, fetchError]);
 
+  const visiblePerks = useMemo(
+    () =>
+      workflowsEnabled
+        ? perks
+        : perks.filter((perk) => perk.redemptionType !== "workflow"),
+    [perks, workflowsEnabled],
+  );
+
   const featuredPerks = useMemo(
-    () => perks.filter((perk) => perk.isFeatured),
-    [perks],
+    () => visiblePerks.filter((perk) => perk.isFeatured),
+    [visiblePerks],
   );
 
   const featuredIds = useMemo(
@@ -387,16 +397,18 @@ const Perks = () => {
 
   const allSectionPerks = useMemo(
     () =>
-      showFeaturedSection ? perks.filter((p) => !featuredIds.has(p.id)) : perks,
-    [perks, showFeaturedSection, featuredIds],
+      showFeaturedSection
+        ? visiblePerks.filter((p) => !featuredIds.has(p.id))
+        : visiblePerks,
+    [visiblePerks, showFeaturedSection, featuredIds],
   );
 
   const detailsPerk = useMemo(
     () =>
       detailsPerkId
-        ? (perks.find((perk) => perk.id === detailsPerkId) ?? null)
+        ? (visiblePerks.find((perk) => perk.id === detailsPerkId) ?? null)
         : null,
-    [detailsPerkId, perks],
+    [detailsPerkId, visiblePerks],
   );
 
   useEffect(() => {

--- a/src/pages/admin/AdminPerks.tsx
+++ b/src/pages/admin/AdminPerks.tsx
@@ -371,9 +371,6 @@ export default function AdminPerks() {
   const { can } = useAdminAuth();
   const { workflowsEnabled } = useFeatureFlags();
   const canWrite = can("subscriptions.write");
-  const availableRedemptionTypes = workflowsEnabled
-    ? REDEMPTION_TYPES
-    : REDEMPTION_TYPES.filter((type) => type.value !== "workflow");
 
   const [perks, setPerks] = useState<AdminPerk[]>([]);
   const [expiredPerks, setExpiredPerks] = useState<AdminPerk[]>([]);
@@ -395,6 +392,12 @@ export default function AdminPerks() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [form, setForm] = useState<PerkFormState>(emptyForm());
+  const showDisabledWorkflowType =
+    !workflowsEnabled && Boolean(editingId) && form.redemptionType === "workflow";
+  const availableRedemptionTypes =
+    workflowsEnabled || showDisabledWorkflowType
+      ? REDEMPTION_TYPES
+      : REDEMPTION_TYPES.filter((type) => type.value !== "workflow");
   const [dialogError, setDialogError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -1550,8 +1553,17 @@ export default function AdminPerks() {
                   </SelectTrigger>
                   <SelectContent>
                     {availableRedemptionTypes.map((type) => (
-                      <SelectItem key={type.value} value={type.value}>
+                      <SelectItem
+                        key={type.value}
+                        value={type.value}
+                        disabled={
+                          type.value === "workflow" && !workflowsEnabled
+                        }
+                      >
                         {type.label}
+                        {type.value === "workflow" && !workflowsEnabled
+                          ? " (disabled)"
+                          : ""}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/pages/admin/AdminPerks.tsx
+++ b/src/pages/admin/AdminPerks.tsx
@@ -38,6 +38,7 @@ import {
   type PerkRedemptionType,
 } from "@/auth/backend";
 import { useAdminAuth } from "@/contexts/AdminAuthContext";
+import { useFeatureFlags } from "@/lib/feature-flags";
 import {
   AudienceTargetingPanel,
 } from "@/components/admin/AudienceTargetingPanel";
@@ -368,7 +369,11 @@ function statusLabel(status: AdminPerk["status"]) {
 
 export default function AdminPerks() {
   const { can } = useAdminAuth();
+  const { workflowsEnabled } = useFeatureFlags();
   const canWrite = can("subscriptions.write");
+  const availableRedemptionTypes = workflowsEnabled
+    ? REDEMPTION_TYPES
+    : REDEMPTION_TYPES.filter((type) => type.value !== "workflow");
 
   const [perks, setPerks] = useState<AdminPerk[]>([]);
   const [expiredPerks, setExpiredPerks] = useState<AdminPerk[]>([]);
@@ -1544,7 +1549,7 @@ export default function AdminPerks() {
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {REDEMPTION_TYPES.map((type) => (
+                    {availableRedemptionTypes.map((type) => (
                       <SelectItem key={type.value} value={type.value}>
                         {type.label}
                       </SelectItem>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduce backend-driven client feature flags and a new tabbed Account workspace. This lets us toggle Workflows/AI Assistant from the backend and delivers a cleaner, consistent account UI. Also fixes session token checks to prevent unauthenticated Friends calls.

- New Features
  - Added `useFeatureFlags`, `fetchClientFeatureFlags`, and `resetFeatureFlags` in `src/lib/feature-flags.ts`; loads from `${BACKEND_URL}/config/features` with 5m in-memory cache, generation-scoped in-flight dedupe, 5s timeout, safe JSON parsing/defaults, and abort-on-reset; tests cover reset races and stale responses.
  - Admin sidebar shows Workflows only when `workflowsEnabled`.
  - Perks: hide workflow-type perks when off; category filters only show valid categories and auto-reset selection; featured/all sections and detail views use the filtered set.
  - Admin Perks: hide the "workflow" redemption type when disabled; keep it visible but disabled and labeled "(disabled)" when editing an existing workflow perk.
  - New Account workspace: `AccountWorkspace` with tabs (Perks, Vault, Profile, Connections), deep-linkable hash/query, synced URL state, and smooth scrolling. Introduced `WorkspacePanel` and `workspace-ui` helpers; updated AI Assistant, Workflows, Secure Vault, Email Preferences, Linked Accounts, Connected Devices, and Membership Sharing to use the new panel styles. Secure Vault now edits fields in a modal with safe value loading and race-safe save/remove.

- Bug Fixes
  - Friends badge and Friends page now use `hasSessionToken` before fetching, preventing unauthenticated requests and clearing state when signed out.

<sup>Written for commit 7520df301b8d8dcaee3d74cc8beded80ec48f0ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Keen-VPN/website/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

