### PR TITLE
Tighten pricing page copy and spacing

### DIFF
--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -146,7 +146,7 @@ export function transformApiPlans(apiPlans: ApiPlan[]): PricingPlan[] {
       description: isPremium
         ? "Perfect for personal use"
         : isTeam
-          ? "Buy seats for your whole team — pay per person"
+          ? "Buy seats for your whole team, pay per person"
           : "Premium VPN service",
       monthlyPrice,
       annualPrice,

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -310,7 +310,7 @@ const Pricing = () => {
         )}
 
         {/* Pricing Cards */}
-        <section id="plans" className="container mx-auto px-4 mb-20">
+        <section id="plans" className="container mx-auto px-4 mt-16 md:mt-20 mb-20">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-7xl mx-auto items-stretch">
             {plans.map((plan, index) => {
               const isAnnual = billingPeriod === "annual";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Team plan copy (“Buy seats for your whole team, pay per person”) and added responsive top margin to the plans section to improve readability and spacing.

<sup>Written for commit a6e8db610935e087b2280ee39d29940e75a42930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Keen-VPN/website/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

