### PR TITLE
Pass stored web UTMs into native app deep links.

### DIFF
--- a/src/lib/keenvpn-deep-links.ts
+++ b/src/lib/keenvpn-deep-links.ts
@@ -1,3 +1,4 @@
+import { appendStoredUtmsToDeepLink } from "@/lib/utm-attribution";
 import {
   APP_STORE_URLS,
   isAppleAppStoreUrl,
@@ -29,7 +30,8 @@ const ASWEB_AUTH_AUTO_OPEN_DONE_KEY = "keenvpn_asweb_auth_auto_open_done";
 
 const STRIPE_CHECKOUT_RETURN_KEY = "keenvpn_stripe_checkout_return";
 const STRIPE_AUTO_OPEN_DONE_KEY = "keenvpn_stripe_auto_open_done";
-const STRIPE_POST_CHECKOUT_UI_DISMISSED_KEY = "keenvpn_stripe_post_checkout_ui_dismissed";
+const STRIPE_POST_CHECKOUT_UI_DISMISSED_KEY =
+  "keenvpn_stripe_post_checkout_ui_dismissed";
 
 function readStripeCheckoutReturnId(): string | null {
   try {
@@ -42,7 +44,10 @@ function readStripeCheckoutReturnId(): string | null {
 /** Stripe redirects to `/account?session_id=…` after checkout. */
 export function markStripeCheckoutReturn(sessionId?: string | null): void {
   try {
-    sessionStorage.setItem(STRIPE_CHECKOUT_RETURN_KEY, sessionId?.trim() || "1");
+    sessionStorage.setItem(
+      STRIPE_CHECKOUT_RETURN_KEY,
+      sessionId?.trim() || "1",
+    );
   } catch {
     /* private mode / blocked storage */
   }
@@ -85,7 +90,9 @@ export function shouldShowStripePostCheckoutUi(): boolean {
     return false;
   }
   try {
-    return sessionStorage.getItem(STRIPE_POST_CHECKOUT_UI_DISMISSED_KEY) !== returnId;
+    return (
+      sessionStorage.getItem(STRIPE_POST_CHECKOUT_UI_DISMISSED_KEY) !== returnId
+    );
   } catch {
     return false;
   }
@@ -162,10 +169,12 @@ export function openKeenVpnNativeApp(
     return;
   }
 
+  const resolvedDeepLink = appendStoredUtmsToDeepLink(deepLink);
+
   try {
     const iframe = document.createElement("iframe");
     iframe.style.display = "none";
-    iframe.src = deepLink;
+    iframe.src = resolvedDeepLink;
     document.body.appendChild(iframe);
     window.setTimeout(() => iframe.remove(), 500);
   } catch {
@@ -173,7 +182,7 @@ export function openKeenVpnNativeApp(
   }
 
   const anchor = document.createElement("a");
-  anchor.href = deepLink;
+  anchor.href = resolvedDeepLink;
   document.body.appendChild(anchor);
   anchor.click();
   window.setTimeout(() => anchor.remove(), 100);
@@ -238,7 +247,9 @@ export function shouldAutoOpenAppAfterAsWebAuth(sessionToken: string): boolean {
     return false;
   }
   try {
-    return sessionStorage.getItem(ASWEB_AUTH_AUTO_OPEN_DONE_KEY) !== sessionToken;
+    return (
+      sessionStorage.getItem(ASWEB_AUTH_AUTO_OPEN_DONE_KEY) !== sessionToken
+    );
   } catch {
     return false;
   }

--- a/src/lib/utm-attribution.ts
+++ b/src/lib/utm-attribution.ts
@@ -127,3 +127,30 @@ export function getUtmAttributionAuthPayload(): UtmAttributionAuthPayload {
   if (!stored) return {};
   return { utmAttribution: stored };
 }
+
+export function appendStoredUtmsToDeepLink(deepLink: string): string {
+  const stored = getStoredUtmAttribution();
+  if (!stored) return deepLink;
+
+  try {
+    const url = new URL(deepLink);
+    const keys = [
+      "utm_source",
+      "utm_medium",
+      "utm_campaign",
+      "utm_content",
+      "utm_term",
+      "landing_path",
+      "captured_at",
+    ] as const;
+    for (const key of keys) {
+      const value = stored[key];
+      if (value && !url.searchParams.has(key)) {
+        url.searchParams.set(key, value);
+      }
+    }
+    return url.toString();
+  } catch {
+    return deepLink;
+  }
+}

--- a/src/lib/utm-attribution.ts
+++ b/src/lib/utm-attribution.ts
@@ -145,7 +145,11 @@ export function appendStoredUtmsToDeepLink(deepLink: string): string {
     ] as const;
     for (const key of keys) {
       const value = stored[key];
-      if (value && !url.searchParams.has(key)) {
+      if (
+        typeof value === "string" &&
+        value.trim() &&
+        !url.searchParams.has(key)
+      ) {
         url.searchParams.set(key, value);
       }
     }


### PR DESCRIPTION
Append first-touch attribution params when handing off from the in-app browser so native sign-ups inherit the same campaign context.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass stored web UTM parameters into native app deep links so installs and sign-ups keep the same campaign context during web-to-app handoff. Preserves first-touch attribution without overriding existing params.

- **New Features**
  - Added `appendStoredUtmsToDeepLink` to merge stored UTM fields into a deep link.
  - Applied in `openKeenVpnNativeApp` for both iframe and anchor flows using a single resolved link.
  - Supports: utm_source, utm_medium, utm_campaign, utm_content, utm_term, `landing_path`, `captured_at`.
  - Safe behavior: no UTMs stored → no-op; existing params are kept; invalid URLs return the original link.

<sup>Written for commit 0b94349c40cff65d1a199ef40041b373a4a2d5d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Keen-VPN/website/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

