### PR TITLE
Staging

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -2506,7 +2506,13 @@ export interface AdminWeeklySessionKpiSummary {
   iso_week: number;
   week_label: string;
   week_range_label: string;
+  /** Users with ≥1 qualifying VPN connection OR ≥1 perk click-through in the week. */
   active_users: number;
+  active_users_with_connections?: number;
+  active_users_with_perk_clicks?: number;
+  active_users_vpn_only?: number;
+  active_users_perk_only?: number;
+  active_users_vpn_and_perk?: number;
   median_connections_per_user: number;
   total_connections: number;
   median_connection_seconds: number;
@@ -2525,11 +2531,13 @@ export interface AdminWeeklySessionKpiReport {
   week_over_week: {
     previous_week: string;
     active_users: number;
+    active_users_with_connections?: number;
     median_connections_per_user: number;
     total_connections: number;
     median_connection_seconds: number;
     total_connection_seconds: number;
     delta_active_users: number;
+    delta_active_users_with_connections?: number;
     delta_median_connections: number;
   } | null;
   segments: {
@@ -2583,6 +2591,8 @@ export interface AdminChurnReport {
   year: number;
   monthLabel: string;
   startOfMonthActiveUsers: number;
+  startOfMonthTrialUsers?: number;
+  startOfMonthPaidUsers?: number;
   hardChurned: number;
   hardChurnRate: number;
   churnedFromCancellation: number;
@@ -2636,13 +2646,26 @@ export interface AdminWeeklyChurnClientPlatformBreakdown {
   subscriptionExpirations: number;
 }
 
+export interface AdminWeeklyChurnSubscriptionStatusBreakdown {
+  subscriptionStatus: "trial" | "paid";
+  activeAtWeekStart: number;
+  churned: number;
+  churnRate: number;
+  autoRenewDisabled: number;
+  subscriptionExpirations: number;
+}
+
 export interface AdminWeeklyChurnReport {
   isoYear: number;
   isoWeek: number;
   weekLabel: string;
   weekRangeLabel: string;
   startOfWeekActiveUsers: number;
+  startOfWeekTrialUsers?: number;
+  startOfWeekPaidUsers?: number;
   churned: number;
+  churnedTrialUsers?: number;
+  churnedPaidUsers?: number;
   churnRate: number;
   churnedFromCancellation: number;
   accountsDeleted: number;
@@ -2651,6 +2674,7 @@ export interface AdminWeeklyChurnReport {
   subscriptionExpirations: number;
   subscriptionExpirationsRate: number;
   subscriptionSourceFilter: string | null;
+  bySubscriptionStatus?: AdminWeeklyChurnSubscriptionStatusBreakdown[];
   bySubscriptionSource: AdminWeeklyChurnSubscriptionSourceBreakdown[];
   byClientPlatform: AdminWeeklyChurnClientPlatformBreakdown[];
 }

--- a/src/pages/admin/AdminChurn.tsx
+++ b/src/pages/admin/AdminChurn.tsx
@@ -255,7 +255,11 @@ export default function AdminChurn() {
         <SummaryCard
           title="Active at month start"
           value={report ? String(report.startOfMonthActiveUsers) : "—"}
-          subtitle={formatMonthLabel(month, year)}
+          subtitle={
+            report
+              ? `${report.startOfMonthPaidUsers ?? report.startOfMonthActiveUsers} paid · ${report.startOfMonthTrialUsers ?? 0} trial`
+              : formatMonthLabel(month, year)
+          }
           loading={loading}
         />
         <SummaryCard

--- a/src/pages/admin/AdminChurn.tsx
+++ b/src/pages/admin/AdminChurn.tsx
@@ -256,8 +256,10 @@ export default function AdminChurn() {
           title="Active at month start"
           value={report ? String(report.startOfMonthActiveUsers) : "—"}
           subtitle={
-            report
-              ? `${report.startOfMonthPaidUsers ?? report.startOfMonthActiveUsers} paid · ${report.startOfMonthTrialUsers ?? 0} trial`
+            report &&
+            report.startOfMonthPaidUsers != null &&
+            report.startOfMonthTrialUsers != null
+              ? `${report.startOfMonthPaidUsers} paid · ${report.startOfMonthTrialUsers} trial`
               : formatMonthLabel(month, year)
           }
           loading={loading}

--- a/src/pages/admin/AdminChurnWeekly.tsx
+++ b/src/pages/admin/AdminChurnWeekly.tsx
@@ -53,7 +53,7 @@ function formatWeeklyActiveUsersSubtitle(
   engagement: AdminWeeklySessionKpiReport["summary"] | undefined,
 ): string {
   if (!engagement) {
-    return "VPN session or perk click-through (≥1 each)";
+    return "Unavailable — engagement data failed to load";
   }
   if (
     engagement.active_users_vpn_only != null &&
@@ -62,10 +62,7 @@ function formatWeeklyActiveUsersSubtitle(
   ) {
     return `${engagement.active_users_vpn_only} VPN only · ${engagement.active_users_perk_only} perk only · ${engagement.active_users_vpn_and_perk} both`;
   }
-  const viaVpn =
-    engagement.active_users_with_connections ?? engagement.active_users;
-  const viaPerk = engagement.active_users_with_perk_clicks ?? 0;
-  return `${viaVpn} via VPN · ${viaPerk} via perk click`;
+  return "Breakdown unavailable for this week";
 }
 
 function pct(value: number): string {
@@ -155,6 +152,7 @@ export default function AdminChurnWeekly() {
   const [trend, setTrend] = useState<AdminWeeklyChurnTrendReport | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [engagementWarning, setEngagementWarning] = useState<string | null>(null);
   const loadGeneration = useRef(0);
 
   const load = useCallback(
@@ -167,6 +165,7 @@ export default function AdminChurnWeekly() {
 
       setLoading(true);
       setError(null);
+      setEngagementWarning(null);
       setReport(null);
       setEngagement(null);
       setTrend(null);
@@ -207,6 +206,9 @@ export default function AdminChurnWeekly() {
         setEngagement(engagementRes.data);
       } else {
         setEngagement(null);
+        setEngagementWarning(
+          engagementRes.error ?? "Weekly active users unavailable for this week",
+        );
       }
       if (trendRes.ok && trendRes.data) {
         setTrend(trendRes.data);
@@ -319,14 +321,22 @@ export default function AdminChurnWeekly() {
         </div>
       ) : null}
 
+      {engagementWarning ? (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
+          {engagementWarning}
+        </div>
+      ) : null}
+
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
         <SummaryCard
           title="Active at week start"
           value={report ? String(report.startOfWeekActiveUsers) : "—"}
           subtitle={
-            report
-              ? `${report.startOfWeekPaidUsers ?? report.startOfWeekActiveUsers} paid · ${report.startOfWeekTrialUsers ?? 0} trial · ${report.weekRangeLabel}`
-              : weekInputValue
+            report &&
+            report.startOfWeekPaidUsers != null &&
+            report.startOfWeekTrialUsers != null
+              ? `${report.startOfWeekPaidUsers} paid · ${report.startOfWeekTrialUsers} trial · ${report.weekRangeLabel}`
+              : (report?.weekRangeLabel ?? weekInputValue)
           }
           loading={loading}
         />
@@ -351,7 +361,9 @@ export default function AdminChurnWeekly() {
           value={report ? `${report.churned} (${pct(report.churnRate)})` : "—"}
           subtitle={
             report
-              ? `Lost: ${report.churnedPaidUsers ?? report.churned} paid, ${report.churnedTrialUsers ?? 0} trial (${report.churnedFromCancellation} cancelled, ${report.accountsDeleted} deleted)`
+              ? report.churnedPaidUsers != null && report.churnedTrialUsers != null
+                ? `Lost: ${report.churnedPaidUsers} paid, ${report.churnedTrialUsers} trial (${report.churnedFromCancellation} cancelled, ${report.accountsDeleted} deleted)`
+                : `Lost this week: ${report.churnedFromCancellation} cancelled, ${report.accountsDeleted} deleted account${report.accountsDeleted === 1 ? "" : "s"}`
               : "Subscribers lost this week"
           }
           loading={loading}

--- a/src/pages/admin/AdminChurnWeekly.tsx
+++ b/src/pages/admin/AdminChurnWeekly.tsx
@@ -9,9 +9,11 @@ import {
 import {
   adminFetchWeeklyChurnReport,
   adminFetchWeeklyChurnTrend,
+  adminFetchWeeklySessionKpis,
   type AdminChurnSubscriptionSource,
   type AdminWeeklyChurnReport,
   type AdminWeeklyChurnTrendReport,
+  type AdminWeeklySessionKpiReport,
 } from "@/auth/backend";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,6 +36,37 @@ import {
   trendWindowEnd,
   trendWindowStart,
 } from "@/lib/iso-week";
+
+function formatWeeklyActiveUsersValue(
+  engagement: AdminWeeklySessionKpiReport["summary"] | undefined,
+): string {
+  if (!engagement) return "—";
+  return String(engagement.active_users);
+}
+
+function formatSignedInteger(value: number): string {
+  if (value === 0) return "0";
+  return `${value > 0 ? "+" : ""}${value}`;
+}
+
+function formatWeeklyActiveUsersSubtitle(
+  engagement: AdminWeeklySessionKpiReport["summary"] | undefined,
+): string {
+  if (!engagement) {
+    return "VPN session or perk click-through (≥1 each)";
+  }
+  if (
+    engagement.active_users_vpn_only != null &&
+    engagement.active_users_perk_only != null &&
+    engagement.active_users_vpn_and_perk != null
+  ) {
+    return `${engagement.active_users_vpn_only} VPN only · ${engagement.active_users_perk_only} perk only · ${engagement.active_users_vpn_and_perk} both`;
+  }
+  const viaVpn =
+    engagement.active_users_with_connections ?? engagement.active_users;
+  const viaPerk = engagement.active_users_with_perk_clicks ?? 0;
+  return `${viaVpn} via VPN · ${viaPerk} via perk click`;
+}
 
 function pct(value: number): string {
   return `${value.toFixed(2)}%`;
@@ -117,6 +150,8 @@ export default function AdminChurnWeekly() {
   const [source, setSource] = useState<AdminChurnSubscriptionSource>("all");
   const [trendMetric, setTrendMetric] = useState<ChurnTrendMetric>("churned");
   const [report, setReport] = useState<AdminWeeklyChurnReport | null>(null);
+  const [engagement, setEngagement] =
+    useState<AdminWeeklySessionKpiReport | null>(null);
   const [trend, setTrend] = useState<AdminWeeklyChurnTrendReport | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -133,18 +168,25 @@ export default function AdminChurnWeekly() {
       setLoading(true);
       setError(null);
       setReport(null);
+      setEngagement(null);
       setTrend(null);
 
       const from = trendWindowStart(targetYear, targetWeek, 8);
       const to = trendWindowEnd(targetYear, targetWeek);
 
-      const [reportRes, trendRes] = await Promise.all([
+      const [reportRes, trendRes, engagementRes] = await Promise.all([
         adminFetchWeeklyChurnReport({
           year: targetYear,
           week: targetWeek,
           source: targetSource,
         }),
         adminFetchWeeklyChurnTrend({ from, to, source: targetSource }),
+        adminFetchWeeklySessionKpis({
+          year: targetYear,
+          week: targetWeek,
+          minDurationSeconds: 10,
+          includeWow: true,
+        }),
       ]);
 
       if (generation !== loadGeneration.current) {
@@ -153,6 +195,7 @@ export default function AdminChurnWeekly() {
 
       if (!reportRes.ok || !reportRes.data) {
         setReport(null);
+        setEngagement(null);
         setTrend(null);
         setError(reportRes.error ?? "Failed to load weekly churn report");
         setLoading(false);
@@ -160,6 +203,11 @@ export default function AdminChurnWeekly() {
       }
 
       setReport(reportRes.data);
+      if (engagementRes.ok && engagementRes.data) {
+        setEngagement(engagementRes.data);
+      } else {
+        setEngagement(null);
+      }
       if (trendRes.ok && trendRes.data) {
         setTrend(trendRes.data);
       } else {
@@ -216,7 +264,9 @@ export default function AdminChurnWeekly() {
           <p className="text-sm text-muted-foreground">
             ISO week (Monday UTC). Churn = subscribers lost this week (cancellations
             + account deletions) ÷ active at week start. Users who switch billing
-            source are not counted as churned. Internal test accounts are excluded.
+            source are not counted as churned. Weekly active users = VPN session or
+            perk click (breakdown sums to the total). Internal test accounts are
+            excluded.
           </p>
         </div>
         <div className="flex flex-wrap items-end gap-2">
@@ -269,19 +319,39 @@ export default function AdminChurnWeekly() {
         </div>
       ) : null}
 
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
         <SummaryCard
           title="Active at week start"
           value={report ? String(report.startOfWeekActiveUsers) : "—"}
-          subtitle={report?.weekRangeLabel ?? weekInputValue}
+          subtitle={
+            report
+              ? `${report.startOfWeekPaidUsers ?? report.startOfWeekActiveUsers} paid · ${report.startOfWeekTrialUsers ?? 0} trial · ${report.weekRangeLabel}`
+              : weekInputValue
+          }
           loading={loading}
+        />
+        <SummaryCard
+          title="Weekly active users"
+          value={formatWeeklyActiveUsersValue(engagement?.summary)}
+          subtitle={formatWeeklyActiveUsersSubtitle(engagement?.summary)}
+          detail={
+            engagement?.summary.week_range_label ??
+            report?.weekRangeLabel ??
+            weekInputValue
+          }
+          loading={loading}
+          delta={
+            engagement?.week_over_week
+              ? formatSignedInteger(engagement.week_over_week.delta_active_users)
+              : undefined
+          }
         />
         <SummaryCard
           title="Weekly churn"
           value={report ? `${report.churned} (${pct(report.churnRate)})` : "—"}
           subtitle={
             report
-              ? `Lost this week: ${report.churnedFromCancellation} cancelled, ${report.accountsDeleted} deleted account${report.accountsDeleted === 1 ? "" : "s"}`
+              ? `Lost: ${report.churnedPaidUsers ?? report.churned} paid, ${report.churnedTrialUsers ?? 0} trial (${report.churnedFromCancellation} cancelled, ${report.accountsDeleted} deleted)`
               : "Subscribers lost this week"
           }
           loading={loading}
@@ -307,6 +377,52 @@ export default function AdminChurnWeekly() {
           loading={loading}
         />
       </div>
+
+      {!loading && report && report.bySubscriptionStatus && report.bySubscriptionStatus.length > 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Churn by subscription status</CardTitle>
+            <CardDescription>Paid vs free trial at week start.</CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-muted-foreground">
+                  <th className="pb-2 pr-4 font-medium">Status</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Active (start)</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Churned</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Churn %</th>
+                  <th className="pb-2 pr-4 font-medium text-right">Auto-renew off</th>
+                  <th className="pb-2 font-medium text-right">Expirations</th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.bySubscriptionStatus.map((row) => (
+                  <tr
+                    key={row.subscriptionStatus}
+                    className="border-t border-border/60"
+                  >
+                    <td className="py-2 pr-4 capitalize">{row.subscriptionStatus}</td>
+                    <td className="py-2 pr-4 text-right tabular-nums">
+                      {row.activeAtWeekStart}
+                    </td>
+                    <td className="py-2 pr-4 text-right tabular-nums">{row.churned}</td>
+                    <td className="py-2 pr-4 text-right tabular-nums">
+                      {pct(row.churnRate)}
+                    </td>
+                    <td className="py-2 pr-4 text-right tabular-nums">
+                      {row.autoRenewDisabled}
+                    </td>
+                    <td className="py-2 text-right tabular-nums">
+                      {row.subscriptionExpirations}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      ) : null}
 
       {!loading && report && source === "all" && report.bySubscriptionSource.length > 0 ? (
         <Card>
@@ -474,11 +590,15 @@ function SummaryCard({
   value,
   subtitle,
   loading,
+  detail,
+  delta,
 }: {
   title: string;
   value: string;
   subtitle: string;
   loading: boolean;
+  detail?: string;
+  delta?: string;
 }) {
   return (
     <Card>
@@ -486,10 +606,18 @@ function SummaryCard({
         <CardDescription>{title}</CardDescription>
         <CardTitle className="text-2xl tabular-nums">
           {loading ? "…" : value}
+          {!loading && delta ? (
+            <span className="ml-2 text-sm font-normal text-muted-foreground">
+              ({delta} WoW)
+            </span>
+          ) : null}
         </CardTitle>
       </CardHeader>
       <CardContent>
         <p className="text-xs text-muted-foreground">{subtitle}</p>
+        {detail ? (
+          <p className="mt-1 text-xs text-muted-foreground">{detail}</p>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/src/pages/admin/AdminChurnWeekly.tsx
+++ b/src/pages/admin/AdminChurnWeekly.tsx
@@ -184,7 +184,6 @@ export default function AdminChurnWeekly() {
           year: targetYear,
           week: targetWeek,
           minDurationSeconds: 10,
-          includeWow: true,
         }),
       ]);
 
@@ -345,9 +344,11 @@ export default function AdminChurnWeekly() {
           value={formatWeeklyActiveUsersValue(engagement?.summary)}
           subtitle={formatWeeklyActiveUsersSubtitle(engagement?.summary)}
           detail={
-            engagement?.summary.week_range_label ??
-            report?.weekRangeLabel ??
-            weekInputValue
+            source !== "all"
+              ? `All users (not filtered by ${source === "stripe" ? "Stripe" : "Apple"}) · ${report?.weekRangeLabel ?? weekInputValue}`
+              : (engagement?.summary.week_range_label ??
+                report?.weekRangeLabel ??
+                weekInputValue)
           }
           loading={loading}
           delta={

--- a/src/pages/admin/AdminConnectionEngagement.tsx
+++ b/src/pages/admin/AdminConnectionEngagement.tsx
@@ -332,8 +332,8 @@ export default function AdminConnectionEngagement() {
         <div>
           <h2 className="text-2xl font-bold">Connection engagement</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            Weekly session KPIs and monthly median usage (UTC). Internal test
-            accounts are excluded.
+            VPN session usage (UTC). Weekly active users (VPN + perks) are on
+            the weekly churn tab. Internal test accounts are excluded.
           </p>
         </div>
         <div className="inline-flex rounded-lg border border-border p-1">

--- a/src/pages/admin/AdminConnectionEngagementWeekly.tsx
+++ b/src/pages/admin/AdminConnectionEngagementWeekly.tsx
@@ -283,7 +283,10 @@ export default function AdminConnectionEngagementWeekly() {
     () =>
       (trend?.points ?? []).map((p) => ({
         label: p.week_label,
-        vpnUsers: p.active_users_with_connections ?? 0,
+        vpnUsers:
+          p.active_users_with_connections != null
+            ? p.active_users_with_connections
+            : null,
         medianConnections: p.median_connections_per_user,
         totalConnections: p.total_connections,
         medianConnectionSeconds: p.median_connection_seconds,
@@ -538,6 +541,7 @@ export default function AdminConnectionEngagementWeekly() {
                   stroke={`var(--color-${selectedTrendMetric.dataKey})`}
                   strokeWidth={2}
                   dot={false}
+                  connectNulls={false}
                 />
               </LineChart>
             </ChartContainer>

--- a/src/pages/admin/AdminConnectionEngagementWeekly.tsx
+++ b/src/pages/admin/AdminConnectionEngagementWeekly.tsx
@@ -54,7 +54,7 @@ function formatDuration(seconds: number): string {
 }
 
 type EngagementTrendMetric =
-  | "active_users"
+  | "vpn_users"
   | "median_connections"
   | "total_connections"
   | "median_connection_time"
@@ -69,9 +69,9 @@ const ENGAGEMENT_TREND_METRICS: {
   allowDecimals: boolean;
 }[] = [
   {
-    value: "active_users",
-    label: "Active users",
-    dataKey: "activeUsers",
+    value: "vpn_users",
+    label: "VPN users",
+    dataKey: "vpnUsers",
     color: "hsl(var(--primary))",
     formatValue: (value) => String(Math.round(value)),
     allowDecimals: false,
@@ -190,7 +190,7 @@ export default function AdminConnectionEngagementWeekly() {
   const [error, setError] = useState<string | null>(null);
   const [trendWarning, setTrendWarning] = useState<string | null>(null);
   const [trendMetric, setTrendMetric] =
-    useState<EngagementTrendMetric>("active_users");
+    useState<EngagementTrendMetric>("vpn_users");
   const activeRequest = useRef<AbortController | null>(null);
 
   const load = useCallback(
@@ -283,7 +283,7 @@ export default function AdminConnectionEngagementWeekly() {
     () =>
       (trend?.points ?? []).map((p) => ({
         label: p.week_label,
-        activeUsers: p.active_users,
+        vpnUsers: p.active_users_with_connections ?? p.active_users,
         medianConnections: p.median_connections_per_user,
         totalConnections: p.total_connections,
         medianConnectionSeconds: p.median_connection_seconds,
@@ -315,8 +315,8 @@ export default function AdminConnectionEngagementWeekly() {
       <div>
         <h3 className="text-lg font-semibold">Weekly session KPIs</h3>
         <p className="text-sm text-muted-foreground">
-          ISO week (Monday UTC). Sessions count after min duration filter.
-          Internal test accounts are excluded.
+          ISO week (Monday UTC). VPN connection metrics only — sessions count
+          after min duration filter. Internal test accounts are excluded.
         </p>
       </div>
 
@@ -416,17 +416,28 @@ export default function AdminConnectionEngagementWeekly() {
 
       <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
         <KpiCard
-          title="Active users"
-          value={report ? String(report.summary.active_users) : "—"}
-          subtitle="Unique users who connected"
+          title="VPN users"
+          value={
+            report
+              ? String(
+                  report.summary.active_users_with_connections ??
+                    report.summary.active_users,
+                )
+              : "—"
+          }
+          subtitle="Unique users with a qualifying VPN session"
           detail={report?.summary.week_range_label}
           loading={loading}
-          delta={wow ? formatDelta(wow.delta_active_users) : undefined}
+          delta={
+            wow
+              ? formatDelta(wow.delta_active_users_with_connections ?? wow.delta_active_users)
+              : undefined
+          }
         />
         <KpiCard
           title="Median connections"
           value={report ? String(report.summary.median_connections_per_user) : "—"}
-          subtitle="Per active user"
+          subtitle="Per user with VPN sessions"
           loading={loading}
           delta={wow ? formatDelta(wow.delta_median_connections, true) : undefined}
         />

--- a/src/pages/admin/AdminConnectionEngagementWeekly.tsx
+++ b/src/pages/admin/AdminConnectionEngagementWeekly.tsx
@@ -283,7 +283,7 @@ export default function AdminConnectionEngagementWeekly() {
     () =>
       (trend?.points ?? []).map((p) => ({
         label: p.week_label,
-        vpnUsers: p.active_users_with_connections ?? p.active_users,
+        vpnUsers: p.active_users_with_connections ?? 0,
         medianConnections: p.median_connections_per_user,
         totalConnections: p.total_connections,
         medianConnectionSeconds: p.median_connection_seconds,
@@ -418,19 +418,16 @@ export default function AdminConnectionEngagementWeekly() {
         <KpiCard
           title="VPN users"
           value={
-            report
-              ? String(
-                  report.summary.active_users_with_connections ??
-                    report.summary.active_users,
-                )
+            report && report.summary.active_users_with_connections != null
+              ? String(report.summary.active_users_with_connections)
               : "—"
           }
           subtitle="Unique users with a qualifying VPN session"
           detail={report?.summary.week_range_label}
           loading={loading}
           delta={
-            wow
-              ? formatDelta(wow.delta_active_users_with_connections ?? wow.delta_active_users)
+            wow && wow.delta_active_users_with_connections != null
+              ? formatDelta(wow.delta_active_users_with_connections)
               : undefined
           }
         />


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add weekly active users to Churn Weekly with a VPN/perk breakdown and WoW delta, plus paid vs trial churn splits on weekly and monthly views. Clarify VPN-only metrics on Connection Engagement and fix VPN trend gaps; the WAU card always shows all users (ignores the billing source filter).

- **New Features**
  - Churn Weekly: new “Weekly active users” KPI with VPN-only, perk-only, and both breakdown plus WoW delta; shows week range and notes it is unfiltered by source.
  - Churn splits: paid vs trial table on Churn Weekly; monthly and weekly “Active at start” cards show paid/trial counts when available.

- **Bug Fixes**
  - Connection Engagement Weekly shows VPN users only, defaults trend metric to “VPN users,” and skips missing trend points instead of plotting zero; copy directs to Churn Weekly for total WAU.
  - Safer fallbacks: only show paid/trial splits when the API provides them and surface a warning if engagement data fails to load.

<sup>Written for commit d820c51f2718617771ca051ff2113c7161920e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Keen-VPN/website/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

