### PR TITLE
fix

### DIFF
--- a/src/components/FriendDiscoveriesSection.tsx
+++ b/src/components/FriendDiscoveriesSection.tsx
@@ -115,7 +115,8 @@ export function FriendDiscoveriesSection({
   const [counts, setCounts] = useState({ new: 0, saved: 0, pending: 0 });
   const [sharingMode, setSharingMode] =
     useState<DiscoverySharingMode>("review");
-  const sharingModeRequestRef = useRef(0);
+  const sharingModeInflightRef = useRef(false);
+  const sharingModePendingRef = useRef<DiscoverySharingMode | null>(null);
   const [loading, setLoading] = useState(true);
   const [actingId, setActingId] = useState<string | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
@@ -162,21 +163,53 @@ export function FriendDiscoveriesSection({
     void load();
   }, [load, refreshKey]);
 
+  async function flushSharingModeUpdates(token: string) {
+    if (sharingModeInflightRef.current) return;
+    sharingModeInflightRef.current = true;
+
+    try {
+      while (sharingModePendingRef.current !== null) {
+        const next = sharingModePendingRef.current;
+        sharingModePendingRef.current = null;
+
+        const res = await updateDiscoveryPreferences(token, next);
+
+        // A newer selection arrived while this request was in flight — flush that next.
+        if (sharingModePendingRef.current !== null) continue;
+
+        if (!res.ok) {
+          toast({
+            title: "Could not update preference",
+            description: res.error,
+            variant: "destructive",
+          });
+          // Reconcile UI with whatever the server actually persisted.
+          const prefRes = await fetchDiscoveryPreferences(token);
+          if (sharingModePendingRef.current !== null) continue;
+          if (prefRes.ok && prefRes.data) {
+            setSharingMode(prefRes.data.sharingMode);
+          }
+          continue;
+        }
+
+        setSharingMode(next);
+      }
+    } finally {
+      sharingModeInflightRef.current = false;
+      // A change may have been queued after the loop exited but before inflight cleared.
+      if (sharingModePendingRef.current !== null) {
+        void flushSharingModeUpdates(token);
+      }
+    }
+  }
+
   async function handleSharingModeChange(mode: DiscoverySharingMode) {
     const token = getSessionToken();
     if (!token) return;
-    const requestId = ++sharingModeRequestRef.current;
-    const res = await updateDiscoveryPreferences(token, mode);
-    if (requestId !== sharingModeRequestRef.current) return;
-    if (!res.ok) {
-      toast({
-        title: "Could not update preference",
-        description: res.error,
-        variant: "destructive",
-      });
-      return;
-    }
+
+    sharingModePendingRef.current = mode;
     setSharingMode(mode);
+    await flushSharingModeUpdates(token);
   }
 
   async function openShareDialog() {

--- a/src/components/FriendDiscoveriesSection.tsx
+++ b/src/components/FriendDiscoveriesSection.tsx
@@ -115,6 +115,7 @@ export function FriendDiscoveriesSection({
   const [counts, setCounts] = useState({ new: 0, saved: 0, pending: 0 });
   const [sharingMode, setSharingMode] =
     useState<DiscoverySharingMode>("review");
+  const sharingModeRequestRef = useRef(0);
   const [loading, setLoading] = useState(true);
   const [actingId, setActingId] = useState<string | null>(null);
   const [shareOpen, setShareOpen] = useState(false);
@@ -164,17 +165,18 @@ export function FriendDiscoveriesSection({
   async function handleSharingModeChange(mode: DiscoverySharingMode) {
     const token = getSessionToken();
     if (!token) return;
-    const previous = sharingMode;
-    setSharingMode(mode);
+    const requestId = ++sharingModeRequestRef.current;
     const res = await updateDiscoveryPreferences(token, mode);
+    if (requestId !== sharingModeRequestRef.current) return;
     if (!res.ok) {
-      setSharingMode(previous);
       toast({
         title: "Could not update preference",
         description: res.error,
         variant: "destructive",
       });
+      return;
     }
+    setSharingMode(mode);
   }
 
   async function openShareDialog() {

--- a/src/components/SecureVaultCard.tsx
+++ b/src/components/SecureVaultCard.tsx
@@ -34,6 +34,7 @@ import { VaultFieldInput } from "@/components/VaultFieldInput";
 import {
   getVaultFieldValidationError,
   isSensitiveVaultField,
+  normalizeVaultFieldValueForSave,
 } from "@/lib/vault-fields";
 import { cn } from "@/lib/utils";
 
@@ -130,7 +131,7 @@ export function SecureVaultCard({ sessionToken }: SecureVaultCardProps) {
   }
 
   async function handleSave(field: VaultFieldMetadata) {
-    const trimmed = editValue.trim();
+    const trimmed = normalizeVaultFieldValueForSave(field.fieldKey, editValue);
     const validationError = getVaultFieldValidationError(field.fieldKey, trimmed);
     if (validationError) {
       setError(validationError);

--- a/src/components/WorkflowPerkDialog.tsx
+++ b/src/components/WorkflowPerkDialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/auth/backend";
 import { getUserProfileInformation, type ProfileQuestion } from "@/auth";
 import { getVisibleWorkflowQuestionKeys } from "@/components/WorkflowQuestionFields";
-import { getVaultAnswersValidationError } from "@/lib/vault-fields";
+import { getVaultAnswersValidationError, normalizeVaultFieldValueForSave } from "@/lib/vault-fields";
 import { WorkflowMissingInputFields } from "@/components/WorkflowMissingInputFields";
 import { WorkflowVaultConsentPanel } from "@/components/WorkflowVaultConsentPanel";
 import {
@@ -223,7 +223,10 @@ export function WorkflowPerkDialog({
     }
     const sanitized = Object.fromEntries(
       visibleQuestionKeys
-        .map((key) => [key, (answers[key] ?? "").trim()])
+        .map((key) => [
+          key,
+          normalizeVaultFieldValueForSave(key, answers[key] ?? ""),
+        ])
         .filter(([, value]) => value.length > 0),
     );
     setSubmitting(true);

--- a/src/components/WorkflowsCard.tsx
+++ b/src/components/WorkflowsCard.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/auth/backend";
 import { getUserProfileInformation, type ProfileQuestion } from "@/auth";
 import { getVisibleWorkflowQuestionKeys } from "@/components/WorkflowQuestionFields";
-import { getVaultAnswersValidationError } from "@/lib/vault-fields";
+import { getVaultAnswersValidationError, normalizeVaultFieldValueForSave } from "@/lib/vault-fields";
 import { WorkflowMissingInputFields } from "@/components/WorkflowMissingInputFields";
 import { WorkflowVaultConsentPanel } from "@/components/WorkflowVaultConsentPanel";
 import {
@@ -245,7 +245,10 @@ export function WorkflowsCard({ sessionToken }: WorkflowsCardProps) {
     }
     const sanitized = Object.fromEntries(
       visibleQuestionKeys
-        .map((key) => [key, (answers[key] ?? "").trim()])
+        .map((key) => [
+          key,
+          normalizeVaultFieldValueForSave(key, answers[key] ?? ""),
+        ])
         .filter(([, value]) => value.length > 0),
     );
     setSubmitting(true);

--- a/src/lib/vault-fields.ts
+++ b/src/lib/vault-fields.ts
@@ -170,11 +170,13 @@ export function parseVaultAddress(value: string): VaultAddress {
 
 /** Serialize address fields to the JSON string the vault API expects. */
 export function serializeVaultAddress(address: VaultAddress): string {
-  const line1 = address.line1.trim();
-  const line2 = address.line2?.trim() ?? "";
-  const city = address.city.trim();
-  const state = address.state.trim();
-  const postalCode = address.postalCode.trim();
+  // Do not trim here — this runs on every keystroke while editing. Trimming
+  // would drop trailing spaces and merge words (e.g. "123 Main" → "123Main").
+  const line1 = address.line1;
+  const line2 = address.line2 ?? "";
+  const city = address.city;
+  const state = address.state;
+  const postalCode = address.postalCode;
 
   if (!line1 && !line2 && !city && !state && !postalCode) {
     return "";
@@ -183,6 +185,29 @@ export function serializeVaultAddress(address: VaultAddress): string {
   const payload: VaultAddress = { line1, city, state, postalCode };
   if (line2) payload.line2 = line2;
   return JSON.stringify(payload);
+}
+
+/** Trim address field values for vault persistence / API submit. */
+export function normalizeVaultAddressValue(value: string): string {
+  const address = parseVaultAddress(value);
+  return serializeVaultAddress({
+    line1: address.line1.trim(),
+    line2: address.line2?.trim() ?? "",
+    city: address.city.trim(),
+    state: address.state.trim(),
+    postalCode: address.postalCode.trim(),
+  });
+}
+
+/** Normalize a vault field value before validation + persistence. */
+export function normalizeVaultFieldValueForSave(
+  fieldKey: string,
+  value: string,
+): string {
+  if (fieldKey === "home_address" || fieldKey === "mailing_address") {
+    return normalizeVaultAddressValue(value);
+  }
+  return value.trim();
 }
 
 export function isValidSsn(value: string): boolean {
@@ -273,7 +298,7 @@ export function getVaultAnswersValidationError(
 ): string | null {
   for (const key of keys) {
     if (!isVaultFieldKey(key)) continue;
-    const value = (answers[key] ?? "").trim();
+    const value = normalizeVaultFieldValueForSave(key, answers[key] ?? "");
     if (!value) continue;
     const error = getVaultFieldValidationError(key, value);
     if (error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes address input trimming and discovery sharing mode race conditions to prevent data loss and inconsistent UI. Address values are normalized only on save, and sharing preference changes are queued so only the latest choice applies.

- **Bug Fixes**
  - Address fields: stop trimming while typing to avoid merging words (e.g., "123 Main"). Normalize on save/submit in Secure Vault and workflow dialogs; validation uses the same normalized values.
  - Discovery sharing mode: queue and process rapid toggles sequentially so only the latest selection applies; on failure, show an error and sync the UI to the server’s saved preference.

<sup>Written for commit 628acfea5be2488b583fccb21bddbdf81690c5ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Keen-VPN/website/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

