### PR TITLE
feat: gate account workspace by entitlement

### DIFF
--- a/src/auth/backend.ts
+++ b/src/auth/backend.ts
@@ -3,7 +3,12 @@ import type {
   VaultFieldCategory,
   VaultFieldInputType,
 } from "@/lib/vault-fields";
-import { BackendAuthResponse, SubscriptionData, TrialData } from "./types";
+import {
+  BackendAuthResponse,
+  SubscriptionData,
+  TrialData,
+  UserEntitlements,
+} from "./types";
 import {
   getReferralTokenFromStorage,
   clearReferralTokenStorage,
@@ -190,6 +195,7 @@ function normalizeBackendAuthResponse(
 export interface SubscriptionStatusResult {
   success: boolean;
   hasActiveSubscription?: boolean;
+  entitlements: UserEntitlements | null;
   subscription: SubscriptionData | null;
   trial: TrialData | null;
   annualSavings?: {
@@ -199,6 +205,20 @@ export interface SubscriptionStatusResult {
   } | null;
   error?: string;
   unauthorized?: boolean;
+}
+
+function parseUserEntitlements(value: unknown): UserEntitlements | null {
+  if (!isJsonObject(value) || !isJsonObject(value.workspace)) return null;
+
+  const { enabled, reason } = value.workspace;
+  const validReason =
+    reason === "active_subscription" ||
+    reason === "active_trial" ||
+    reason === "not_eligible";
+
+  if (typeof enabled !== "boolean" || !validReason) return null;
+
+  return { workspace: { enabled, reason } };
 }
 
 // ============================================================================
@@ -1559,6 +1579,7 @@ export async function fetchSubscriptionStatusWithSession(
     if (!response.ok) {
       return {
         success: false,
+        entitlements: null,
         subscription: null,
         trial: null,
         error: data?.error || "Failed to fetch subscription status",
@@ -1579,10 +1600,14 @@ export async function fetchSubscriptionStatusWithSession(
             }
           ).annualSavings ?? null)
         : null;
+    const entitlements = isJsonObject(data)
+      ? parseUserEntitlements(data.entitlements)
+      : null;
 
     return {
       success: normalized.success,
       hasActiveSubscription: Boolean(normalized.subscription),
+      entitlements,
       subscription: normalized.subscription ?? null,
       trial: normalized.trial ?? null,
       annualSavings,
@@ -1592,6 +1617,7 @@ export async function fetchSubscriptionStatusWithSession(
   } catch (error) {
     return {
       success: false,
+      entitlements: null,
       subscription: null,
       trial: null,
       annualSavings: null,

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -159,6 +159,8 @@ export {
 export type {
   SubscriptionData,
   TrialData,
+  UserEntitlements,
+  WorkspaceEntitlementReason,
   AuthState,
   BackendAuthResponse
 } from './types';

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -32,10 +32,23 @@ export interface TrialData {
   tier?: string | null;
 }
 
+export type WorkspaceEntitlementReason =
+  | "active_subscription"
+  | "active_trial"
+  | "not_eligible";
+
+export interface UserEntitlements {
+  workspace: {
+    enabled: boolean;
+    reason: WorkspaceEntitlementReason;
+  };
+}
+
 export interface AuthState {
   user: FirebaseUser | null;
   subscription: SubscriptionData | null;
   trial: TrialData | null;
+  entitlements: UserEntitlements | null;
   loading: boolean;
 }
 

--- a/src/components/AccountWorkspace.tsx
+++ b/src/components/AccountWorkspace.tsx
@@ -119,10 +119,10 @@ export function AccountWorkspace({
   const navigate = useNavigate();
   const bodyScrollRef = useRef<HTMLDivElement>(null);
   const impressionTrackedRef = useRef(false);
-  const lastTrackedTabRef = useRef<AccountWorkspaceTab | null>(null);
   const [activeTab, setActiveTab] = useState<AccountWorkspaceTab>(() =>
     resolveTabFromLocation(location.search, location.hash),
   );
+  const lastTrackedTabRef = useRef<AccountWorkspaceTab>(activeTab);
   const [mountedTabs, setMountedTabs] = useState<Set<AccountWorkspaceTab>>(
     () =>
       new Set([

--- a/src/components/AccountWorkspace.tsx
+++ b/src/components/AccountWorkspace.tsx
@@ -18,6 +18,7 @@ import { AiAssistantCard } from "@/components/AiAssistantCard";
 import { UserInformationCard } from "@/components/UserInformationCard";
 import { EmailPreferencesCard } from "@/components/EmailPreferencesCard";
 import { cn } from "@/lib/utils";
+import { trackWorkspaceEvent } from "@/lib/product-analytics";
 
 export type AccountWorkspaceTab =
   | "perks"
@@ -117,6 +118,8 @@ export function AccountWorkspace({
   const location = useLocation();
   const navigate = useNavigate();
   const bodyScrollRef = useRef<HTMLDivElement>(null);
+  const impressionTrackedRef = useRef(false);
+  const lastTrackedTabRef = useRef<AccountWorkspaceTab | null>(null);
   const [activeTab, setActiveTab] = useState<AccountWorkspaceTab>(() =>
     resolveTabFromLocation(location.search, location.hash),
   );
@@ -126,6 +129,24 @@ export function AccountWorkspace({
         resolveTabFromLocation(location.search, location.hash),
       ]),
   );
+
+  useEffect(() => {
+    if (impressionTrackedRef.current) return;
+    impressionTrackedRef.current = true;
+    trackWorkspaceEvent("workspace_impression", {
+      entry_section: activeTab,
+      navigation_path: `${location.pathname}${location.search}${location.hash}`,
+    });
+  }, [activeTab, location.hash, location.pathname, location.search]);
+
+  useEffect(() => {
+    if (lastTrackedTabRef.current === activeTab) return;
+    lastTrackedTabRef.current = activeTab;
+    trackWorkspaceEvent("workspace_feature_opened", {
+      section: activeTab,
+      navigation_path: `${location.pathname}${location.search}${location.hash}`,
+    });
+  }, [activeTab, location.hash, location.pathname, location.search]);
 
   useEffect(() => {
     setMountedTabs((prev) => {
@@ -254,7 +275,7 @@ export function AccountWorkspace({
             <div ref={bodyScrollRef} className="relative min-h-0 flex-1">
               <TabsContent
                 value="perks"
-                forceMount={mountedTabs.has("perks")}
+                forceMount={mountedTabs.has("perks") ? true : undefined}
                 className={cn(tabPanelClassName, "space-y-4")}
               >
                 <div id="applications" className="scroll-mt-24 space-y-4">
@@ -265,7 +286,7 @@ export function AccountWorkspace({
 
               <TabsContent
                 value="vault"
-                forceMount={mountedTabs.has("vault")}
+                forceMount={mountedTabs.has("vault") ? true : undefined}
                 className={tabPanelClassName}
               >
                 <div id="vault" className="scroll-mt-24">
@@ -275,7 +296,7 @@ export function AccountWorkspace({
 
               <TabsContent
                 value="profile"
-                forceMount={mountedTabs.has("profile")}
+                forceMount={mountedTabs.has("profile") ? true : undefined}
                 className={cn(tabPanelClassName, "space-y-4")}
               >
                 <div className="grid gap-4 xl:grid-cols-2">
@@ -286,7 +307,7 @@ export function AccountWorkspace({
 
               <TabsContent
                 value="connections"
-                forceMount={mountedTabs.has("connections")}
+                forceMount={mountedTabs.has("connections") ? true : undefined}
                 className={cn(tabPanelClassName, "space-y-4")}
               >
                 <div className="grid gap-4 xl:grid-cols-2">

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -158,6 +158,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const response = await fetchSubscriptionStatusWithSession(sessionToken);
 
       if (response.success) {
+        // Ignore a response from a session that was replaced while this
+        // request was in flight (for example, logout followed by another login).
+        if (getSessionToken() !== sessionToken) {
+          return null;
+        }
         setSubscription(response.subscription ?? null);
         setTrial(response.trial ?? null);
         setEntitlements(response.entitlements);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,6 +21,7 @@ import {
   RETENTION_WINBACK_TOKEN_STORAGE_KEY,
   type SubscriptionData,
   type TrialData,
+  type UserEntitlements,
   type SignInResult,
   getSignupSourceStatus,
 } from '@/auth';
@@ -51,6 +52,7 @@ interface AuthContextType {
   user: FirebaseUser | null;
   subscription: SubscriptionData | null;
   trial: TrialData | null;
+  entitlements: UserEntitlements | null;
   loading: boolean;
   isAuthenticating: boolean;
   linkedProviders: LinkedProviders | null;
@@ -73,6 +75,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [user, setUser] = useState<FirebaseUser | null>(null);
   const [subscription, setSubscription] = useState<SubscriptionData | null>(null);
   const [trial, setTrial] = useState<TrialData | null>(null);
+  const [entitlements, setEntitlements] = useState<UserEntitlements | null>(null);
   const [loading, setLoading] = useState(true);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [linkedProviders, setLinkedProviders] = useState<LinkedProviders | null>(null);
@@ -157,6 +160,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (response.success) {
         setSubscription(response.subscription ?? null);
         setTrial(response.trial ?? null);
+        setEntitlements(response.entitlements);
         return response.subscription;
       }
       if (response.unauthorized) {
@@ -170,6 +174,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setUser(null);
           setSubscription(null);
           setTrial(null);
+          setEntitlements(null);
           try {
             await firebaseSignOut();
           } catch {
@@ -338,6 +343,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
               setUser(null);
               setSubscription(null);
               setTrial(null);
+              setEntitlements(null);
 
               toast({
                 title: "Account Recently Deleted",
@@ -359,6 +365,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
               setUser(null);
               setSubscription(null);
               setTrial(null);
+              setEntitlements(null);
 
               toast({
                 title: "Sign-In Failed",
@@ -496,6 +503,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
                 setUser(null);
                 setSubscription(null);
                 setTrial(null);
+                setEntitlements(null);
 
                 toast({
                   title: "Sign-In Failed",
@@ -517,6 +525,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           if (!getSessionToken()) {
             setSubscription(null);
             setTrial(null);
+            setEntitlements(null);
           }
           setAuthProvider(null);
           syncHasSessionToken();
@@ -695,6 +704,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
               setUser(null);
               setSubscription(null);
               setTrial(null);
+              setEntitlements(null);
               try {
                 await firebaseSignOut();
               } catch {
@@ -801,6 +811,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setUser(null);
         setSubscription(null);
         setTrial(null);
+        setEntitlements(null);
 
         setIsAuthenticating(false);
 
@@ -827,6 +838,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setUser(null);
         setSubscription(null);
         setTrial(null);
+        setEntitlements(null);
 
         toast({
           title: "Sign-In Failed",
@@ -872,6 +884,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setUser(null);
       setSubscription(null);
       setTrial(null);
+      setEntitlements(null);
       setAuthProvider(null);
 
       toast({
@@ -922,6 +935,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     user,
     subscription,
     trial,
+    entitlements,
     loading,
     isAuthenticating,
     linkedProviders,
@@ -931,7 +945,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     logout,
     refreshSubscription,
     refreshLinkedProviders,
-  }), [user, subscription, trial, loading, isAuthenticating, hasSessionToken, linkedProviders, authProvider, signIn, logout, refreshSubscription, refreshLinkedProviders]);
+  }), [user, subscription, trial, entitlements, loading, isAuthenticating, hasSessionToken, linkedProviders, authProvider, signIn, logout, refreshSubscription, refreshLinkedProviders]);
 
   const sessionTokenForSignupSource = React.useMemo(() => {
     if (!hasSessionToken || !signupSourceDialogOpen) {
@@ -966,4 +980,3 @@ export const useAuth = () => {
   }
   return context;
 };
-

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -48,11 +48,14 @@ interface LinkedProviders {
   apple: { linked: boolean; email?: string };
 }
 
+type EntitlementsStatus = "idle" | "loading" | "ready" | "error";
+
 interface AuthContextType {
   user: FirebaseUser | null;
   subscription: SubscriptionData | null;
   trial: TrialData | null;
   entitlements: UserEntitlements | null;
+  entitlementsStatus: EntitlementsStatus;
   loading: boolean;
   isAuthenticating: boolean;
   linkedProviders: LinkedProviders | null;
@@ -76,6 +79,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [subscription, setSubscription] = useState<SubscriptionData | null>(null);
   const [trial, setTrial] = useState<TrialData | null>(null);
   const [entitlements, setEntitlements] = useState<UserEntitlements | null>(null);
+  const [entitlementsStatus, setEntitlementsStatus] =
+    useState<EntitlementsStatus>("idle");
   const [loading, setLoading] = useState(true);
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [linkedProviders, setLinkedProviders] = useState<LinkedProviders | null>(null);
@@ -154,6 +159,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   // ============================================================================
 
   const fetchSubscriptionFromBackend = React.useCallback(async (sessionToken: string) => {
+    if (getSessionToken() === sessionToken) {
+      setEntitlementsStatus("loading");
+    }
     try {
       const response = await fetchSubscriptionStatusWithSession(sessionToken);
 
@@ -166,6 +174,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         setSubscription(response.subscription ?? null);
         setTrial(response.trial ?? null);
         setEntitlements(response.entitlements);
+        setEntitlementsStatus(response.entitlements ? "ready" : "error");
         return response.subscription;
       }
       if (response.unauthorized) {
@@ -180,15 +189,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           setSubscription(null);
           setTrial(null);
           setEntitlements(null);
+          setEntitlementsStatus("idle");
           try {
             await firebaseSignOut();
           } catch {
             // Ignore sign-out errors while clearing invalid auth state.
           }
         }
+      } else if (getSessionToken() === sessionToken) {
+        setEntitlementsStatus("error");
       }
       return null;
     } catch {
+      if (getSessionToken() === sessionToken) {
+        setEntitlementsStatus("error");
+      }
       return null;
     }
   }, [setAuthProvider]);
@@ -890,6 +905,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setSubscription(null);
       setTrial(null);
       setEntitlements(null);
+      setEntitlementsStatus("idle");
       setAuthProvider(null);
 
       toast({
@@ -941,6 +957,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     subscription,
     trial,
     entitlements,
+    entitlementsStatus,
     loading,
     isAuthenticating,
     linkedProviders,
@@ -950,7 +967,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     logout,
     refreshSubscription,
     refreshLinkedProviders,
-  }), [user, subscription, trial, entitlements, loading, isAuthenticating, hasSessionToken, linkedProviders, authProvider, signIn, logout, refreshSubscription, refreshLinkedProviders]);
+  }), [user, subscription, trial, entitlements, entitlementsStatus, loading, isAuthenticating, hasSessionToken, linkedProviders, authProvider, signIn, logout, refreshSubscription, refreshLinkedProviders]);
 
   const sessionTokenForSignupSource = React.useMemo(() => {
     if (!hasSessionToken || !signupSourceDialogOpen) {

--- a/src/lib/product-analytics.ts
+++ b/src/lib/product-analytics.ts
@@ -45,6 +45,25 @@ export function trackProductEngagement(
   );
 }
 
+export type WorkspaceEventName =
+  | "workspace_impression"
+  | "workspace_feature_opened";
+
+export function trackWorkspaceEvent(
+  eventName: WorkspaceEventName,
+  payload: ProductAnalyticsPayload = {},
+): void {
+  if (typeof window === "undefined") return;
+
+  const detail = {
+    ...payload,
+    event: eventName,
+  };
+
+  window.dataLayer?.push(detail);
+  window.dispatchEvent(new CustomEvent("keen_workspace", { detail }));
+}
+
 export type SwitchPageEventName =
   | "switch_page_viewed"
   | "switch_cta_clicked"

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -136,6 +136,7 @@ const Account = () => {
     logout,
     subscription,
     trial,
+    entitlements,
     refreshSubscription,
     linkedProviders,
     refreshLinkedProviders,
@@ -148,6 +149,7 @@ const Account = () => {
     subscription,
     trial,
   );
+  const workspaceEnabled = entitlements?.workspace.enabled === true;
   const canManageBilling = subscription?.canManageBilling === true;
 
   const isDeepLinkSupported = useMemo(() => isAppDeepLinkSupported(), []);
@@ -1118,7 +1120,7 @@ const Account = () => {
             </Card>
           </div>
 
-          {hasSessionToken && (
+          {hasSessionToken && workspaceEnabled && (
             <AccountWorkspace
               sessionToken={getSessionToken() ?? ""}
               authProvider={authProvider ?? undefined}

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -150,17 +150,19 @@ const Account = () => {
     subscription,
     trial,
   );
-  const workspaceEnabled = entitlements?.workspace.enabled === true;
-  const mayHaveWorkspaceAccess = Boolean(subscription || trial?.active);
+  const workspaceEnabled =
+    entitlementsStatus === "ready" &&
+    entitlements?.workspace.enabled === true;
+  const mayHaveWorkspaceAccess = Boolean(
+    subscription || trial?.active || entitlements?.workspace.enabled,
+  );
   const workspaceEntitlementLoading =
     hasSessionToken &&
     mayHaveWorkspaceAccess &&
-    !entitlements &&
     (entitlementsStatus === "idle" || entitlementsStatus === "loading");
   const workspaceEntitlementError =
     hasSessionToken &&
     mayHaveWorkspaceAccess &&
-    !entitlements &&
     entitlementsStatus === "error";
   const canManageBilling = subscription?.canManageBilling === true;
 

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -137,6 +137,7 @@ const Account = () => {
     subscription,
     trial,
     entitlements,
+    entitlementsStatus,
     refreshSubscription,
     linkedProviders,
     refreshLinkedProviders,
@@ -150,6 +151,17 @@ const Account = () => {
     trial,
   );
   const workspaceEnabled = entitlements?.workspace.enabled === true;
+  const mayHaveWorkspaceAccess = Boolean(subscription || trial?.active);
+  const workspaceEntitlementLoading =
+    hasSessionToken &&
+    mayHaveWorkspaceAccess &&
+    !entitlements &&
+    (entitlementsStatus === "idle" || entitlementsStatus === "loading");
+  const workspaceEntitlementError =
+    hasSessionToken &&
+    mayHaveWorkspaceAccess &&
+    !entitlements &&
+    entitlementsStatus === "error";
   const canManageBilling = subscription?.canManageBilling === true;
 
   const isDeepLinkSupported = useMemo(() => isAppDeepLinkSupported(), []);
@@ -1130,6 +1142,43 @@ const Account = () => {
                 refreshSubscription();
               }}
             />
+          )}
+
+          {workspaceEntitlementLoading && (
+            <Card className="mt-10 border-accent/40 shadow-card">
+              <CardHeader>
+                <Skeleton className="h-7 w-36" />
+                <Skeleton className="h-4 w-full max-w-md" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-24 w-full rounded-xl" />
+              </CardContent>
+            </Card>
+          )}
+
+          {workspaceEntitlementError && (
+            <Card className="mt-10 border-accent/40 shadow-card">
+              <CardHeader>
+                <CardTitle className="text-xl">Workspace unavailable</CardTitle>
+                <CardDescription>
+                  We couldn&apos;t confirm your Workspace access. Refresh your
+                  membership status to try again.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleRefreshSubscription()}
+                  disabled={subscriptionLoading}
+                >
+                  {subscriptionLoading ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : null}
+                  Refresh status
+                </Button>
+              </CardContent>
+            </Card>
           )}
 
           <div className="mt-8 grid gap-6 md:grid-cols-2">


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keen-vpn/website/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the Account Workspace behind user entitlements, add workspace analytics, and show clear loading/error states while entitlements resolve. The workspace now renders only with a current entitlement from the backend.

- **New Features**
  - Parse `entitlements` from the subscription status; add `UserEntitlements` and `WorkspaceEntitlementReason` types and re-export from `@/auth`.
  - Store `entitlements` and `entitlementsStatus` in `AuthContext`; reset on sign-out/error.
  - Render `AccountWorkspace` only when `entitlementsStatus === "ready"` and `entitlements.workspace.enabled === true` (reasons: `active_subscription`, `active_trial`, `not_eligible`). Show a skeleton while entitlements resolve for subscribed/trial users and an error card with “Refresh status” on failure.
  - Add workspace analytics: `workspace_impression` (once per visit) and `workspace_feature_opened`, sent via `dataLayer` and a `keen_workspace` CustomEvent.

- **Bug Fixes**
  - Ignore stale subscription responses if the session token changes mid-request to prevent cross-session state leaks.
  - Avoid passing `false` to `TabsContent.forceMount` to prevent unintended mounts.

<sup>Written for commit 8888c78d6a424ac09d328cda5626e32829492d1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Keen-VPN/website/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

